### PR TITLE
Add API routes to list and create anthologies

### DIFF
--- a/apps/backend/src/anthology/dtos/create-anthology.dto.ts
+++ b/apps/backend/src/anthology/dtos/create-anthology.dto.ts
@@ -1,0 +1,78 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsEnum,
+  IsArray,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AnthologyStatus, AnthologyPubLevel } from '../types';
+
+export class CreateAnthologyDto {
+  @ApiProperty({ description: 'Title of the anthology' })
+  @IsString()
+  title: string;
+
+  @ApiProperty({ description: 'Description of the anthology' })
+  @IsString()
+  description: string;
+
+  @ApiProperty({ description: 'Year the anthology was published' })
+  @IsNumber()
+  published_year: number;
+
+  @ApiProperty({
+    description: 'Status of the anthology',
+    enum: AnthologyStatus,
+    example: AnthologyStatus.DRAFTING,
+  })
+  @IsEnum(AnthologyStatus)
+  status: AnthologyStatus;
+
+  @ApiProperty({
+    description: 'Publication level of the anthology',
+    enum: AnthologyPubLevel,
+    example: AnthologyPubLevel.ZINE,
+  })
+  @IsEnum(AnthologyPubLevel)
+  pub_level: AnthologyPubLevel;
+
+  @ApiPropertyOptional({
+    description: 'Programs associated with the anthology',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  programs?: string[];
+
+  @ApiPropertyOptional({ description: 'Inventory count' })
+  @IsOptional()
+  @IsNumber()
+  inventory?: number;
+
+  @ApiPropertyOptional({ description: 'URL to anthology photo' })
+  @IsOptional()
+  @IsString()
+  photo_url?: string;
+
+  @ApiPropertyOptional({ description: 'Genre of the anthology' })
+  @IsOptional()
+  @IsString()
+  genre?: string;
+
+  @ApiPropertyOptional({ description: 'Theme of the anthology' })
+  @IsOptional()
+  @IsString()
+  theme?: string;
+
+  @ApiPropertyOptional({ description: 'ISBN of the anthology' })
+  @IsOptional()
+  @IsString()
+  isbn?: string;
+
+  @ApiPropertyOptional({ description: 'Shopify URL for purchasing' })
+  @IsOptional()
+  @IsString()
+  shopify_url?: string;
+}

--- a/apps/backend/src/library/library.controller.spec.ts
+++ b/apps/backend/src/library/library.controller.spec.ts
@@ -5,6 +5,7 @@ import { LibraryService } from './library.service';
 import { Library } from './library.entity';
 import { Anthology } from '../anthology/anthology.entity';
 import { AnthologyStatus, AnthologyPubLevel } from '../anthology/types';
+import { CreateAnthologyDto } from '../anthology/dtos/create-anthology.dto';
 
 describe('LibraryController', () => {
   let controller: LibraryController;
@@ -34,6 +35,7 @@ describe('LibraryController', () => {
     findOne: jest.fn(),
     getAnthologies: jest.fn(),
     remove: jest.fn(),
+    createAnthology: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -130,6 +132,79 @@ describe('LibraryController', () => {
       expect(result).toEqual(multipleAnthologies);
       expect(result).toHaveLength(3);
       expect(mockLibraryService.getAnthologies).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('createAnthology', () => {
+    const createAnthologyDto: CreateAnthologyDto = {
+      title: 'New Test Anthology',
+      description: 'A newly created test anthology',
+      published_year: 2024,
+      status: AnthologyStatus.DRAFTING,
+      pub_level: AnthologyPubLevel.ZINE,
+      programs: ['New Program'],
+      inventory: 50,
+      photo_url: 'https://example.com/new-photo.jpg',
+      genre: 'Mystery',
+      theme: 'Suspense',
+      isbn: '9876543210',
+      shopify_url: 'https://shopify.com/new-test',
+    };
+
+    it('should create an anthology successfully', async () => {
+      const newAnthology = {
+        ...mockAnthology,
+        id: 2,
+        title: 'New Test Anthology',
+      };
+      mockLibraryService.createAnthology.mockResolvedValue(newAnthology);
+
+      const result = await controller.createAnthology(1, createAnthologyDto);
+
+      expect(result).toEqual(newAnthology);
+      expect(mockLibraryService.createAnthology).toHaveBeenCalledWith(
+        1,
+        createAnthologyDto,
+      );
+    });
+
+    it('should throw NotFoundException when library does not exist', async () => {
+      mockLibraryService.createAnthology.mockRejectedValue(
+        new NotFoundException('Library not found'),
+      );
+
+      await expect(
+        controller.createAnthology(999, createAnthologyDto),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockLibraryService.createAnthology).toHaveBeenCalledWith(
+        999,
+        createAnthologyDto,
+      );
+    });
+
+    it('should create anthology with minimal required fields', async () => {
+      const minimalDto: CreateAnthologyDto = {
+        title: 'Minimal Anthology',
+        description: 'Minimal description',
+        published_year: 2024,
+        status: AnthologyStatus.NOT_STARTED,
+        pub_level: AnthologyPubLevel.CHAPBOOK,
+      };
+
+      const newAnthology = {
+        ...mockAnthology,
+        id: 3,
+        title: 'Minimal Anthology',
+      };
+      mockLibraryService.createAnthology.mockResolvedValue(newAnthology);
+
+      const result = await controller.createAnthology(1, minimalDto);
+
+      expect(result).toEqual(newAnthology);
+      expect(mockLibraryService.createAnthology).toHaveBeenCalledWith(
+        1,
+        minimalDto,
+      );
     });
   });
 

--- a/apps/backend/src/library/library.controller.ts
+++ b/apps/backend/src/library/library.controller.ts
@@ -4,13 +4,23 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Post,
+  Body,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { LibraryService } from './library.service';
 import { AuthGuard } from '@nestjs/passport';
 import { Library } from './library.entity';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { Anthology } from '../anthology/anthology.entity';
+import { CreateAnthologyDto } from '../anthology/dtos/create-anthology.dto';
 
 @ApiTags('Library')
 @ApiBearerAuth()
@@ -31,6 +41,25 @@ export class LibraryController {
     @Param('libraryId', ParseIntPipe) libraryId: number,
   ): Promise<Anthology[]> {
     return this.libraryService.getAnthologies(libraryId);
+  }
+
+  @Post('/:libraryId/anthology')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new anthology in a library' })
+  @ApiResponse({
+    status: 201,
+    description: 'Anthology created successfully',
+    type: Anthology,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Library not found',
+  })
+  async createAnthology(
+    @Param('libraryId', ParseIntPipe) libraryId: number,
+    @Body() createAnthologyDto: CreateAnthologyDto,
+  ): Promise<Anthology> {
+    return this.libraryService.createAnthology(libraryId, createAnthologyDto);
   }
 
   @Delete('/:id')

--- a/apps/backend/src/library/library.module.ts
+++ b/apps/backend/src/library/library.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LibraryController } from './library.controller';
 import { LibraryService } from './library.service';
 import { Library } from './library.entity';
+import { AnthologyService } from '../anthology/anthology.service';
+import { Anthology } from '../anthology/anthology.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Library])],
+  imports: [TypeOrmModule.forFeature([Library, Anthology])],
   controllers: [LibraryController],
-  providers: [LibraryService],
+  providers: [LibraryService, AnthologyService],
 })
 export class LibraryModule {}


### PR DESCRIPTION
### ℹ️ Issue

Closes #12 
Closes #14

### 📝 Description

Implements a GET endpoint on the Library controller which returns all Anthology instances contained within the specified Library instance, and a POST endpoint on the Library controller which creates a new Anthology instance within the specified Library instance.

Briefly list the changes made to the code:
1. Defined the actual endpoint in `LibraryController` as `getLibraryAnthologies`.
2. Defined a getter method `getAnthologies` in `LibraryService` which will throw a `NotFoundException` if the specified Library ID does not exist.
3. In conjunction with Cursor (AI copilot), wrote comprehensive tests for the Library controller and service, including the new endpoints.
4. Created a DTO for the Anthology object for robust input validation.

### ✔️ Verification

Comprehensively reviewed any AI-generated code. Produced 26 tests related to the Library controller and service, which all pass.

Verify by running `yarn test`:
<img width="819" height="271" alt="image" src="https://github.com/user-attachments/assets/8f35a872-bd08-437d-8c09-6838f46ecc4c" />
*See the Notes section for info about the failing test.

### 🏕️ Future Work / Notes

- Identified that the original endpoint URL specified in the ticket did not align with the expected behavior. Richa updated the ticket accordingly.
- Chose to make the return type `Anthology[]` for clarity and ease of pagination. Can easily be refactored to an object like `{ anthologies: Anthology[] }` in the future if needed.
- Future work related to the Anthology controller's fields may require the DTO in `create-anthology.dto.ts` to be updated accordingly.
- There is a test unrelated to my own code which is failing. The same test also fails on `main`. All tests in `library.service.spec.ts` and `library.controller.spec.ts` pass.
