### PR TITLE
UPDATE endpoint for updating an anthology in a library

### DIFF
--- a/apps/backend/src/anthology/dtos/update-anthology.dto.ts
+++ b/apps/backend/src/anthology/dtos/update-anthology.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAnthologyDto } from './create-anthology.dto';
+
+export class UpdateAnthologyDto extends PartialType(CreateAnthologyDto) {}

--- a/apps/backend/src/library/library.controller.spec.ts
+++ b/apps/backend/src/library/library.controller.spec.ts
@@ -36,6 +36,7 @@ describe('LibraryController', () => {
     getAnthologies: jest.fn(),
     remove: jest.fn(),
     createAnthology: jest.fn(),
+    updateAnthology: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -204,6 +205,115 @@ describe('LibraryController', () => {
       expect(mockLibraryService.createAnthology).toHaveBeenCalledWith(
         1,
         minimalDto,
+      );
+    });
+  });
+
+  describe('updateAnthology', () => {
+    it('should update an anthology successfully', async () => {
+      const updateDto = {
+        title: 'Updated Title',
+        description: 'Updated description',
+      };
+
+      const updatedAnthology = {
+        ...mockAnthology,
+        title: 'Updated Title',
+        description: 'Updated description',
+      };
+
+      mockLibraryService.updateAnthology.mockResolvedValue(updatedAnthology);
+
+      const result = await controller.updateAnthology(1, updateDto);
+
+      expect(result).toEqual(updatedAnthology);
+      expect(mockLibraryService.updateAnthology).toHaveBeenCalledWith(
+        1,
+        updateDto,
+      );
+    });
+
+    it('should throw NotFoundException when anthology does not exist', async () => {
+      const updateDto = {
+        title: 'Updated Title',
+      };
+
+      mockLibraryService.updateAnthology.mockRejectedValue(
+        new NotFoundException('Anthology not found'),
+      );
+
+      await expect(controller.updateAnthology(999, updateDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockLibraryService.updateAnthology).toHaveBeenCalledWith(
+        999,
+        updateDto,
+      );
+    });
+
+    it('should update anthology with partial data', async () => {
+      const updateDto = {
+        inventory: 150,
+      };
+
+      const updatedAnthology = {
+        ...mockAnthology,
+        inventory: 150,
+      };
+
+      mockLibraryService.updateAnthology.mockResolvedValue(updatedAnthology);
+
+      const result = await controller.updateAnthology(1, updateDto);
+
+      expect(result).toEqual(updatedAnthology);
+      expect(mockLibraryService.updateAnthology).toHaveBeenCalledWith(
+        1,
+        updateDto,
+      );
+    });
+
+    it('should update anthology status', async () => {
+      const updateDto = {
+        status: AnthologyStatus.ARCHIVED,
+      };
+
+      const updatedAnthology = {
+        ...mockAnthology,
+        status: AnthologyStatus.ARCHIVED,
+      };
+
+      mockLibraryService.updateAnthology.mockResolvedValue(updatedAnthology);
+
+      const result = await controller.updateAnthology(1, updateDto);
+
+      expect(result).toEqual(updatedAnthology);
+      expect(mockLibraryService.updateAnthology).toHaveBeenCalledWith(
+        1,
+        updateDto,
+      );
+    });
+
+    it('should update multiple fields at once', async () => {
+      const updateDto = {
+        title: 'Brand New Title',
+        inventory: 200,
+        status: AnthologyStatus.CAN_BE_SHARED,
+        shopify_url: 'https://shopify.com/updated',
+      };
+
+      const updatedAnthology = {
+        ...mockAnthology,
+        ...updateDto,
+      };
+
+      mockLibraryService.updateAnthology.mockResolvedValue(updatedAnthology);
+
+      const result = await controller.updateAnthology(1, updateDto);
+
+      expect(result).toEqual(updatedAnthology);
+      expect(mockLibraryService.updateAnthology).toHaveBeenCalledWith(
+        1,
+        updateDto,
       );
     });
   });

--- a/apps/backend/src/library/library.controller.ts
+++ b/apps/backend/src/library/library.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Put,
   Body,
   UseGuards,
   HttpCode,
@@ -21,6 +22,7 @@ import {
 } from '@nestjs/swagger';
 import { Anthology } from '../anthology/anthology.entity';
 import { CreateAnthologyDto } from '../anthology/dtos/create-anthology.dto';
+import { UpdateAnthologyDto } from '../anthology/dtos/update-anthology.dto';
 
 @ApiTags('Library')
 @ApiBearerAuth()
@@ -60,6 +62,24 @@ export class LibraryController {
     @Body() createAnthologyDto: CreateAnthologyDto,
   ): Promise<Anthology> {
     return this.libraryService.createAnthology(libraryId, createAnthologyDto);
+  }
+
+  @Put('/anthology/:anthologyId')
+  @ApiOperation({ summary: 'Update an anthology with the given id' })
+  @ApiResponse({
+    status: 200,
+    description: 'Anthology updated successfully',
+    type: Anthology,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Anthology not found',
+  })
+  async updateAnthology(
+    @Param('anthologyId', ParseIntPipe) anthologyId: number,
+    @Body() updateAnthologyDto: UpdateAnthologyDto,
+  ): Promise<Anthology> {
+    return this.libraryService.updateAnthology(anthologyId, updateAnthologyDto);
   }
 
   @Delete('/:id')

--- a/apps/backend/src/library/library.service.ts
+++ b/apps/backend/src/library/library.service.ts
@@ -122,4 +122,11 @@ export class LibraryService {
 
     return anthology;
   }
+
+  async updateAnthology(
+    anthologyId: number,
+    attrs: Partial<Anthology>,
+  ): Promise<Anthology> {
+    return this.anthologyService.update(anthologyId, attrs);
+  }
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes #15 

### 📝 Description

Implements the UPDATE endpoint for anthologies letting users to modify existing anthology records by ID.

Briefly list the changes made to the code:
1. Added `PUT /library/anthology/:anthologyId` endpoint to `LibraryController
2. Implemented `updateAnthology()` method in `LibraryService
3. Added 5 test case

### ✔️ Verification

Wrote 5 test cases in library.controller.spec.t

Used `yarn test library.controller.spec.t` to test.
All original + old test all passes

<img width="1144" height="254" alt="image" src="https://github.com/user-attachments/assets/2754f15b-bef0-462e-937e-90027e365624" />



### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
