### PR TITLE
Add optional publishing_name field to User

### DIFF
--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -1,18 +1,107 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { SignUpDto } from './dtos/sign-up.dto';
+import { User } from '../users/user.entity';
+import { Status } from '../users/types';
 
 describe('AuthController', () => {
   let controller: AuthController;
+  let authService: AuthService;
+  let usersService: UsersService;
 
   beforeEach(async () => {
+    const mockAuthService = {
+      signup: jest.fn(),
+    };
+
+    const mockUsersService = {
+      create: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: UsersService, useValue: mockUsersService },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+    usersService = module.get<UsersService>(UsersService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('createUser', () => {
+    it('should create a user without publishing name', async () => {
+      const signUpDto: SignUpDto = {
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        password: 'password123',
+      };
+
+      const expectedUser: User = {
+        id: 1,
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        status: Status.STANDARD,
+      };
+
+      jest.spyOn(authService, 'signup').mockResolvedValue(undefined);
+      jest.spyOn(usersService, 'create').mockResolvedValue(expectedUser);
+
+      const result = await controller.createUser(signUpDto);
+
+      expect(authService.signup).toHaveBeenCalledWith(signUpDto);
+      expect(usersService.create).toHaveBeenCalledWith(
+        'test@example.com',
+        'John',
+        'Doe',
+        Status.STANDARD,
+        undefined,
+      );
+      expect(result).toEqual(expectedUser);
+    });
+
+    it('should create a user with publishing name', async () => {
+      const signUpDto: SignUpDto = {
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        password: 'password123',
+        publishingName: 'J.D. Writer',
+      };
+
+      const expectedUser: User = {
+        id: 1,
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        status: Status.STANDARD,
+        publishingName: 'J.D. Writer',
+      };
+
+      jest.spyOn(authService, 'signup').mockResolvedValue(undefined);
+      jest.spyOn(usersService, 'create').mockResolvedValue(expectedUser);
+
+      const result = await controller.createUser(signUpDto);
+
+      expect(authService.signup).toHaveBeenCalledWith(signUpDto);
+      expect(usersService.create).toHaveBeenCalledWith(
+        'test@example.com',
+        'John',
+        'Doe',
+        Status.STANDARD,
+        'J.D. Writer',
+      );
+      expect(result).toEqual(expectedUser);
+    });
   });
 });

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  Post,
-  Request,
-  UseGuards,
-} from '@nestjs/common';
+import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
 
 import { SignInDto } from './dtos/sign-in.dto';
 import { SignUpDto } from './dtos/sign-up.dto';
@@ -16,10 +9,10 @@ import { DeleteUserDto } from './dtos/delete-user.dto';
 import { User } from '../users/user.entity';
 import { SignInResponseDto } from './dtos/sign-in-response.dto';
 import { RefreshTokenDto } from './dtos/refresh-token.dto';
-import { AuthGuard } from '@nestjs/passport';
 import { ConfirmPasswordDto } from './dtos/confirm-password.dto';
 import { ForgotPasswordDto } from './dtos/forgot-password.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { Status } from '../users/types';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -42,6 +35,8 @@ export class AuthController {
       signUpDto.email,
       signUpDto.firstName,
       signUpDto.lastName,
+      Status.STANDARD,
+      signUpDto.publishingName,
     );
 
     return user;

--- a/apps/backend/src/auth/dtos/sign-up.dto.ts
+++ b/apps/backend/src/auth/dtos/sign-up.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class SignUpDto {
   @IsString()
@@ -12,4 +12,8 @@ export class SignUpDto {
 
   @IsString()
   password: string;
+
+  @IsOptional()
+  @IsString()
+  publishingName?: string;
 }

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ObjectIdColumn, ObjectId } from 'typeorm';
+import { Entity, Column } from 'typeorm';
 
 import type { Status } from './types';
 
@@ -18,4 +18,7 @@ export class User {
 
   @Column()
   email: string;
+
+  @Column({ nullable: true })
+  publishingName?: string;
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -14,6 +14,7 @@ export class UsersService {
     firstName: string,
     lastName: string,
     status: Status = Status.STANDARD,
+    publishingName?: string,
   ) {
     const userId = (await this.repo.count()) + 1;
     const user = this.repo.create({
@@ -22,6 +23,7 @@ export class UsersService {
       firstName,
       lastName,
       email,
+      publishingName,
     });
 
     return this.repo.save(user);


### PR DESCRIPTION
### ℹ️ Issue

Closes #27 
Closes #28 

### 📝 Description

Added the optional `publishing_name` field to the User entity, and updated `createUser` accordingly. Also added/update any relevant tests and DTOs.

### ✔️ Verification

All backend tests, new and old, are passing
<img width="309" height="131" alt="image" src="https://github.com/user-attachments/assets/f1cbdfaa-32a0-49ed-be55-1c68a1a48521" />