### PR TITLE
Make individual publication page responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 *.env
 *.env.*
 !example.env
+
+# Cache
+.nx/cache

--- a/apps/frontend/src/containers/archived-publications/individual-publication/publication-view.css
+++ b/apps/frontend/src/containers/archived-publications/individual-publication/publication-view.css
@@ -58,13 +58,13 @@
   display: flex;
   gap: 40px;
   align-items: flex-start;
-  flex-wrap: wrap; 
+  flex-wrap: wrap;
 }
 
 .publication-image {
   width: 240px;
   height: 237px;
-  flex: 0 0 240px; 
+  flex: 0 0 240px;
   border-radius: 12px;
   overflow: hidden;
 }
@@ -77,11 +77,11 @@
 }
 
 .publication-info {
-  flex: 1 1 320px; 
+  flex: 1 1 320px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  min-width: 0; 
+  min-width: 0;
 }
 
 .publication-title-section {
@@ -98,7 +98,7 @@
   color: #000;
   margin: 0;
   white-space: pre-wrap;
-  overflow-wrap: anywhere; 
+  overflow-wrap: anywhere;
 }
 
 .publication-author {
@@ -167,7 +167,7 @@
   display: flex;
   gap: 12px;
   align-items: center;
-  min-width: 0; 
+  min-width: 0;
 }
 
 .metadata-row-single {
@@ -302,7 +302,7 @@
   line-height: normal;
   color: #938b88;
   margin: 0;
-  flex: 0 0 180px; 
+  flex: 0 0 180px;
   min-width: 0;
   min-height: 0;
 }
@@ -314,8 +314,8 @@
   line-height: normal;
   color: #3b3330;
   margin: 0;
-  flex: 1 1 auto;  
-  width: auto;     
+  flex: 1 1 auto;
+  width: auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -341,7 +341,7 @@
   display: flex;
   gap: 12px;
   align-items: center;
-  flex-wrap: wrap; 
+  flex-wrap: wrap;
 }
 
 .filter-badge {
@@ -475,7 +475,7 @@
 
 .detail-row-special .sponsor-tags,
 .detail-row-special .status-badge-container {
-  width: auto;        
+  width: auto;
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
@@ -555,7 +555,7 @@
   align-items: center;
   padding: 0;
   text-decoration: none;
-  width: auto;        /* ✅ remove fixed 755px */
+  width: auto; /* ✅ remove fixed 755px */
   flex: 1 1 auto;
   min-width: 0;
   background: none;

--- a/apps/frontend/src/containers/root.css
+++ b/apps/frontend/src/containers/root.css
@@ -275,7 +275,7 @@
 .root-main {
   flex: 1;
   background-color: var(--neutral-100);
-  overflow: hidden;
+  overflow: auto;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes #59 
📝 Description

Edited the CSS in the individual publication view to make the layout responsive when the window size changes. Updated the header layout, metadata rows, and tag groups to wrap and shrink correctly, removed fixed-width constraints that caused content to be cut off, and added responsive padding and layout adjustments for smaller screen sizes.

### ✔️ Verification

Screenshots attached :) 

### 🏕️ (Optional) Future Work / Notes

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/33f22996-b3d3-4517-bdc3-3a28cf738fb6" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/663b27e4-c50f-4666-838b-58647b0cef8f" />
<img width="599" height="797" alt="image" src="https://github.com/user-attachments/assets/34ae8334-c598-4b24-bbef-dcfe42d1621b" />
