### PR TITLE
BOS-83: user auth 

### DIFF
--- a/apps/backend/src/anthology/anthology.controller.ts
+++ b/apps/backend/src/anthology/anthology.controller.ts
@@ -7,12 +7,21 @@ import {
   UseGuards,
   UseInterceptors,
   NotFoundException,
+  Post,
+  Patch,
+  Body,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { AnthologyService } from './anthology.service';
 import { Anthology } from './anthology.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../auth/roles.decorator';
+import { OmchaiRole } from 'src/omchai/omchai.entity';
+import { CreateAnthologyDto } from './dtos/create-anthology.dto';
+import { UpdateAnthologyDto } from './dtos/update-anthology.dto';
 
 @ApiTags('Anthologies')
 @ApiBearerAuth()
@@ -46,5 +55,40 @@ export class AnthologyController {
   ): Promise<{ message: string }> {
     await this.anthologyService.remove(anthologyId);
     return { message: 'Anthology deleted successfully' };
+  }
+
+  @Post()
+  @Roles(OmchaiRole.OWNER, OmchaiRole.MANAGER)
+  @HttpCode(HttpStatus.CREATED)
+  async createAnthology(
+    @Body() createAnthologyDto: CreateAnthologyDto,
+  ): Promise<Anthology> {
+    return this.anthologyService.create(
+      createAnthologyDto.title,
+      createAnthologyDto.description,
+      createAnthologyDto.status,
+      createAnthologyDto.pub_level,
+      createAnthologyDto.programs,
+      createAnthologyDto.photo_url,
+      createAnthologyDto.isbn,
+      createAnthologyDto.shopify_url,
+    );
+  }
+
+  @Patch(':id')
+  @Roles(OmchaiRole.OWNER, OmchaiRole.MANAGER)
+  async updateAnthology(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateAnthologyDto: UpdateAnthologyDto,
+  ): Promise<Anthology> {
+    return this.anthologyService.update(id, updateAnthologyDto);
+  }
+
+  @Post(':id/publish')
+  @Roles(OmchaiRole.OWNER, OmchaiRole.MANAGER)
+  async publishAnthology(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Anthology | { message: string }> {
+    return this.anthologyService.publish(id);
   }
 }

--- a/apps/backend/src/anthology/anthology.entity.ts
+++ b/apps/backend/src/anthology/anthology.entity.ts
@@ -42,8 +42,8 @@ export class Anthology {
   @Column({ type: 'simple-array', default: [] })
   triggers: string[];
 
-  @Column({ name: 'published_date', type: 'date' })
-  publishedDate: Date;
+  @Column({ name: 'published_date', type: 'date', nullable: true })
+  publishedDate?: Date;
 
   @Column({ type: 'simple-array', nullable: true })
   programs?: string[];

--- a/apps/backend/src/anthology/anthology.service.spec.ts
+++ b/apps/backend/src/anthology/anthology.service.spec.ts
@@ -1,0 +1,114 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnthologyService } from './anthology.service';
+import { Anthology } from './anthology.entity';
+import { AnthologyStatus } from './types';
+
+describe('AnthologyService', () => {
+  let service: AnthologyService;
+
+  const mockRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOneBy: jest.fn(),
+    count: jest.fn(),
+    find: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnthologyService,
+        { provide: getRepositoryToken(Anthology), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<AnthologyService>(AnthologyService);
+    jest.clearAllMocks();
+  });
+
+  describe('update', () => {
+    it('throws when anthology does not exist', async () => {
+      mockRepo.findOneBy.mockResolvedValue(null);
+
+      await expect(
+        service.update(999, { title: 'New Title' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('updates and saves anthology when found', async () => {
+      const existing = {
+        id: 1,
+        title: 'Old Title',
+        description: 'Old Description',
+      } as Anthology;
+
+      const updated = {
+        ...existing,
+        title: 'New Title',
+      } as Anthology;
+
+      mockRepo.findOneBy.mockResolvedValue(existing);
+      mockRepo.save.mockResolvedValue(updated);
+
+      const result = await service.update(1, { title: 'New Title' });
+
+      expect(mockRepo.findOneBy).toHaveBeenCalledWith({ id: 1 });
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'New Title' }),
+      );
+      expect(result.title).toBe('New Title');
+    });
+  });
+
+  describe('publish', () => {
+    it('throws when anthology does not exist', async () => {
+      mockRepo.findOneBy.mockResolvedValue(null);
+
+      await expect(service.publish(999)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('returns benign message when already has publishedDate', async () => {
+      const existing = {
+        id: 1,
+        title: 'Test Anthology',
+        publishedDate: new Date('2025-01-15'),
+      } as Anthology;
+
+      mockRepo.findOneBy.mockResolvedValue(existing);
+
+      const result = await service.publish(1);
+
+      expect(mockRepo.save).not.toHaveBeenCalled();
+      expect(result).toEqual({ message: 'Anthology is already published' });
+    });
+
+    it('sets publishedDate when not yet published', async () => {
+      const existing = {
+        id: 1,
+        title: 'Test Anthology',
+        status: AnthologyStatus.DRAFTING,
+        publishedDate: null,
+      } as Anthology;
+
+      mockRepo.findOneBy.mockResolvedValue(existing);
+      mockRepo.save.mockImplementation(async (anthology) => anthology);
+
+      const result = await service.publish(1);
+
+      expect(mockRepo.findOneBy).toHaveBeenCalledWith({ id: 1 });
+      expect(mockRepo.save).toHaveBeenCalled();
+      const savedAnthology = mockRepo.save.mock.calls[0][0];
+      expect(savedAnthology.publishedDate).toBeInstanceOf(Date);
+      expect((result as Anthology).publishedDate).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/apps/backend/src/anthology/anthology.service.ts
+++ b/apps/backend/src/anthology/anthology.service.ts
@@ -14,7 +14,6 @@ export class AnthologyService {
   async create(
     title: string,
     description: string,
-    publishedDate: string,
     status: AnthologyStatus,
     pubLevel: AnthologyPubLevel,
     programs?: string[],
@@ -22,12 +21,9 @@ export class AnthologyService {
     isbn?: string,
     shopifyUrl?: string,
   ) {
-    const anthologyId = (await this.repo.count()) + 1;
     const anthology = this.repo.create({
-      id: anthologyId,
       title,
       description,
-      publishedDate,
       status,
       pubLevel,
       programs,
@@ -93,6 +89,21 @@ export class AnthologyService {
     }
 
     anthology.status = status;
+    return this.repo.save(anthology);
+  }
+
+  async publish(id: number) {
+    const anthology = await this.findOne(id);
+
+    if (!anthology) {
+      throw new NotFoundException('Anthology not found');
+    }
+
+    if (anthology.publishedDate) {
+      return { message: 'Anthology is already published' };
+    }
+
+    anthology.publishedDate = new Date();
     return this.repo.save(anthology);
   }
 }

--- a/apps/backend/src/anthology/dtos/create-anthology.dto.ts
+++ b/apps/backend/src/anthology/dtos/create-anthology.dto.ts
@@ -8,7 +8,6 @@ import {
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AnthologyStatus, AnthologyPubLevel } from '../types';
 
-//TODO: outdated DTO needs to match the schema
 export class CreateAnthologyDto {
   @ApiProperty({ description: 'Title of the anthology' })
   @IsString()
@@ -17,10 +16,6 @@ export class CreateAnthologyDto {
   @ApiProperty({ description: 'Description of the anthology' })
   @IsString()
   description: string;
-
-  @ApiProperty({ description: 'Year the anthology was published' })
-  @IsNumber()
-  published_year: number;
 
   @ApiProperty({
     description: 'Status of the anthology',

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthorModule } from './author/author.module';
+import { AnthologyModule } from './anthology/anthology.module';
 import { InventoryModule } from './inventory/inventory.module';
 import { InventoryHoldingModule } from './inventory-holding/inventory-holding.module';
 import AppDataSource from './data-source';
@@ -12,6 +13,8 @@ import { StoryModule } from './story/story.module';
 import { OmchaiModule } from './omchai/omchai.module';
 import { UsersModule } from './users/users.module';
 import { StoryDraftModule } from './story-draft/story-draft.module';
+import { APP_GUARD } from '@nestjs/core';
+import { RolesGuard } from './auth/auth.guards';
 
 @Module({
   imports: [
@@ -20,6 +23,7 @@ import { StoryDraftModule } from './story-draft/story-draft.module';
       migrations: [], // ensures migrations not run on app startup
     }),
     AuthorModule,
+    AnthologyModule,
     InventoryModule,
     InventoryHoldingModule,
     ProductionInfoModule,
@@ -29,6 +33,12 @@ import { StoryDraftModule } from './story-draft/story-draft.module';
     StoryDraftModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/backend/src/auth/auth.guards.spec.ts
+++ b/apps/backend/src/auth/auth.guards.spec.ts
@@ -1,0 +1,86 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './auth.guards';
+import { ROLES_KEY } from './roles.decorator';
+import { OmchaiRole } from 'src/omchai/omchai.entity';
+
+function makeContext(user: unknown): ExecutionContext {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RolesGuard', () => {
+  let reflector: Reflector;
+  let guard: RolesGuard;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('allows access when no roles are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    const context = makeContext({ role: OmchaiRole.INFORMED });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows access when required roles list is empty', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([]);
+    const context = makeContext({ role: OmchaiRole.INFORMED });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('denies access when user is not present on the request', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([OmchaiRole.OWNER]);
+    const context = makeContext(null);
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('denies access when user has no role', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([OmchaiRole.OWNER]);
+    const context = makeContext({});
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('denies access when user role is not in required roles', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([OmchaiRole.OWNER, OmchaiRole.MANAGER]);
+    const context = makeContext({ role: OmchaiRole.INFORMED });
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('allows access when user role matches one of the required roles', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([
+        OmchaiRole.OWNER,
+        OmchaiRole.MANAGER,
+        OmchaiRole.CONSULTED,
+        OmchaiRole.HELPER,
+      ]);
+    const context = makeContext({ role: OmchaiRole.CONSULTED });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('uses ROLES_KEY when reading metadata', () => {
+    const spy = jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue(undefined);
+    const context = makeContext({ role: OmchaiRole.OWNER });
+    guard.canActivate(context);
+    expect(spy).toHaveBeenCalledWith(
+      ROLES_KEY,
+      expect.arrayContaining([expect.any(Object), expect.any(Object)]),
+    );
+  });
+});

--- a/apps/backend/src/auth/auth.guards.ts
+++ b/apps/backend/src/auth/auth.guards.ts
@@ -1,0 +1,36 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { OmchaiRole } from 'src/omchai/omchai.entity';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+  // If this returns false, Nest will deny access to the route handler
+  // Automatically throwing a Forbidden Exception (403 status code)
+  canActivate(context: ExecutionContext): boolean {
+    // Look for the metadata we set with the @Roles() decorator
+    // Checks in the route handler, then the controller, and makes it undefined if nothing found
+    // Routes take priority over controllers in terms of overriding
+    const requiredRoles = this.reflector.getAllAndOverride<OmchaiRole[]>(
+      ROLES_KEY,
+      [
+        context.getHandler(), // method-level
+        context.getClass(), // controller-level
+      ],
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user || !user.role) {
+      return false;
+    }
+
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/apps/backend/src/auth/jwt.strategy.ts
+++ b/apps/backend/src/auth/jwt.strategy.ts
@@ -3,6 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import CognitoAuthConfig from '../../../shared/aws-exports';
 
 @Injectable()

--- a/apps/backend/src/auth/roles.decorator.ts
+++ b/apps/backend/src/auth/roles.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import { OmchaiRole } from 'src/omchai/omchai.entity';
+
+// Key used to store roles metadata
+export const ROLES_KEY = 'roles';
+// Custom decorator to set roles metadata on route handlers for proper parsing by RolesGuard
+export const Roles = (...roles: OmchaiRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/backend/src/story-draft/story-draft.controller.ts
+++ b/apps/backend/src/story-draft/story-draft.controller.ts
@@ -7,6 +7,7 @@ import {
   UseInterceptors,
   Body,
   Post,
+  Patch,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
@@ -15,6 +16,8 @@ import { CreateStoryDraftDto } from './dto/create-story-draft.dto';
 import { UpdateStoryDraftDto } from './dto/update-story-draft.dto';
 import { StoryDraftService } from './story-draft.service';
 import { EditRound, SubmissionRound } from './types';
+import { Roles } from '../auth/roles.decorator';
+import { OmchaiRole } from 'src/omchai/omchai.entity';
 
 @ApiTags('StoryDrafts')
 @ApiBearerAuth()
@@ -42,6 +45,12 @@ export class StoryDraftController {
   }
 
   @Post('/:storyDraftId')
+  @Roles(
+    OmchaiRole.OWNER,
+    OmchaiRole.MANAGER,
+    OmchaiRole.CONSULTED,
+    OmchaiRole.HELPER,
+  )
   async editStoryDraft(
     @Param('storyDraftId', ParseIntPipe) storyDraftId: number,
     @Body() updateStoryDraftDto: UpdateStoryDraftDto,

--- a/apps/backend/src/story/story.controller.ts
+++ b/apps/backend/src/story/story.controller.ts
@@ -25,11 +25,10 @@ import {
 import { AnthologyService } from '../anthology/anthology.service';
 import { AuthorService } from '../author/author.service';
 import { CreateStoryDto } from './dtos/create-story.dto';
-import { create } from 'domain';
 
 @ApiTags('Story')
 @ApiBearerAuth()
-@Controller('story')
+@Controller('stories')
 @UseGuards(AuthGuard('jwt'))
 @UseInterceptors(CurrentUserInterceptor)
 export class StoryController {


### PR DESCRIPTION
### ℹ️ Issue

Closes #83 

### 📝 Description

Created and implemented 1st 4 endpoints as specified in given ticket with unit tests inspired from SSF's implementation of guards. NOTE: this guard assumes that the request.user is populated before running, so unable to run integration tests yet. I recommend that we replace CurrentUserInterceptor with SSF's implementation of another JwtGuard, but will wait till standup to check-in.

Question: what does it mean to convert a draft into a story. What fields get transferred? Need guidance on 5th endpoint.

### ✔️ Verification

Created unit tests.


