### PR TITLE
added document tracker tab + story draft upload modal

### DIFF
--- a/apps/frontend/src/app.tsx
+++ b/apps/frontend/src/app.tsx
@@ -16,6 +16,7 @@ import ProtectedRoute from '@containers/auth/ProtectedRoute';
 import People from '@containers/people';
 import Role from '@api/dtos/role';
 import CreatePublicationModal from '@containers/create-publication-modal';
+import ProjectPublicationView from '@containers/projects-publication/project-publication-view';
 
 const router = createBrowserRouter([
   {
@@ -64,7 +65,7 @@ const router = createBrowserRouter([
               },
               {
                 path: 'publication/:id?',
-                element: <PublicationView />,
+                element: <ProjectPublicationView />,
               },
             ],
           },

--- a/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
+++ b/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import '../../containers/create-publication-modal/styles.css';
+
+interface Props {
+  onClose: () => void;
+  onSave: (draft: {
+    firstName: string;
+    lastName: string;
+    nameInBook: string;
+    classPeriod: string;
+    docLink: string;
+  }) => void;
+}
+
+interface FieldProps {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+function Field({ label, required = false, children }: FieldProps) {
+  return (
+    <div className="field">
+      <label className="field__label">
+        {label} {required && <span className="field__required">*</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+export default function NewStoryDraftModal({ onClose, onSave }: Props) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [nameInBook, setNameInBook] = useState('');
+  const [classPeriod, setClassPeriod] = useState('');
+  const [docLink, setDocLink] = useState('');
+
+  const isValid = firstName.trim() && lastName.trim() && docLink.trim();
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      nameInBook,
+      classPeriod,
+      docLink,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <div className="modal__header">
+          <div className="modal__header-row">
+            <h1 className="modal__title">New Story Draft</h1>
+            <button className="modal__close" onClick={onClose}>×</button>
+          </div>
+        </div>
+
+        <div className="modal__body">
+          <div className="field-row">
+            <Field label="First Name" required>
+              <input
+                className="input"
+                placeholder="Author's first name"
+                value={firstName}
+                onChange={e => setFirstName(e.target.value)}
+              />
+            </Field>
+            <Field label="Last Name" required>
+              <input
+                className="input"
+                placeholder="Author's last name"
+                value={lastName}
+                onChange={e => setLastName(e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <Field label="Name in Book">
+            <input
+              className="input"
+              placeholder="Author's name as it appears in the book"
+              value={nameInBook}
+              onChange={e => setNameInBook(e.target.value)}
+            />
+          </Field>
+
+          <Field label="Class Period">
+            <input
+              className="input"
+              placeholder="e.g. Edwards 1/6"
+              value={classPeriod}
+              onChange={e => setClassPeriod(e.target.value)}
+            />
+          </Field>
+
+          <Field label="Document Link" required>
+            <input
+              className="input"
+              placeholder="Paste Google Doc or Drive link"
+              value={docLink}
+              onChange={e => setDocLink(e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <div className="modal__footer">
+          <div className="modal__footer-right">
+            <button className="btn btn--secondary" onClick={onClose}>Cancel</button>
+            <button
+              className="btn btn--primary"
+              onClick={handleSave}
+              disabled={!isValid}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.css
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.css
@@ -1,0 +1,86 @@
+.ppv-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background-color: var(--neutral-100);
+  padding: 24px 100px 104px;
+  box-sizing: border-box;
+}
+
+.ppv-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--neutral-400);
+  margin-bottom: 24px;
+}
+
+.ppv-breadcrumb-link {
+  color: var(--neutral-400);
+  text-decoration: none;
+}
+
+.ppv-breadcrumb-link:hover { text-decoration: underline; }
+
+.ppv-breadcrumb-sep { color: var(--neutral-400); }
+
+.ppv-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.ppv-title {
+  font-family: var(--font-heading);
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--neutral-600);
+  margin: 0;
+}
+
+.ppv-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.document-tracker-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.document-tracker-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+
+.document-tracker-table th,
+.document-tracker-table td {
+  text-align: left;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--neutral-300);
+  color: var(--neutral-600);
+}
+
+.document-tracker-table th {
+  font-weight: 700;
+  background-color: var(--neutral-200);
+}
+
+.archive-modal-content input {
+  display: block;
+  width: 100%;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--neutral-300);
+  border-radius: 8px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  box-sizing: border-box;
+}

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import apiClient from '../../api/apiClient';
+import { Anthology } from '../../types';
+import NewStoryDraftModal from './new-story-draft-modal';
+import './project-publication-view.css';
+
+interface StoryDraftRow {
+  firstName: string;
+  lastName: string;
+  nameInBook: string;
+  classPeriod: string;
+  docLink: string;
+}
+
+const ProjectPublicationView: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [anthology, setAnthology] = useState<Anthology | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [storyDrafts, setStoryDrafts] = useState<StoryDraftRow[]>([]);
+
+  useEffect(() => {
+    if (id) {
+      apiClient.getAnthology(id)
+        .then((data) => { setAnthology(data); setLoading(false); })
+        .catch(() => setLoading(false));
+    }
+  }, [id]);
+
+  if (loading) return <div className="ppv-wrapper">Loading...</div>;
+  if (!anthology) return <div className="ppv-wrapper">No publication found.</div>;
+
+  return (
+    <div className="ppv-wrapper">
+      <div className="ppv-breadcrumb">
+        <a href="/projects/drafts" className="ppv-breadcrumb-link">Projects</a>
+        <span className="ppv-breadcrumb-sep">›</span>
+        <span>{anthology.title}</span>
+      </div>
+
+      <div className="ppv-content">
+        <h1 className="ppv-title">{anthology.title}</h1>
+
+        <div className="publication-tabs">
+          <span className="publication-tab publication-tab--active">Document Tracker</span>
+        </div>
+
+        <div className="ppv-tab-content">
+          <div className="document-tracker-header">
+            <button
+              type="button"
+              className="publication-create-btn"
+              onClick={() => setIsModalOpen(true)}
+            >
+              New Story Draft
+            </button>
+          </div>
+
+          <table className="document-tracker-table">
+            <thead>
+              <tr>
+                <th>First Name</th>
+                <th>Last Name</th>
+                <th>Name in Book</th>
+                <th>Class Period</th>
+                <th>Document Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              {storyDrafts.length === 0 ? (
+                <tr>
+                  <td colSpan={5} style={{ textAlign: 'center', color: 'var(--neutral-400)', padding: '24px' }}>
+                    No story drafts yet.
+                  </td>
+                </tr>
+              ) : (
+                storyDrafts.map((draft, i) => (
+                  <tr key={i}>
+                    <td>{draft.firstName}</td>
+                    <td>{draft.lastName}</td>
+                    <td>{draft.nameInBook}</td>
+                    <td>{draft.classPeriod}</td>
+                    <td><a href={draft.docLink} target="_blank" rel="noreferrer">Open</a></td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <NewStoryDraftModal
+          onClose={() => setIsModalOpen(false)}
+          onSave={(draft) => setStoryDrafts((prev) => [...prev, draft])}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ProjectPublicationView;


### PR DESCRIPTION
### ℹ️ Issue

Closes #105 

### 📝 Description

Adds an individual publication page for the projects flow that has a Document Tracker tab (allows admin and volunteer members to upload student story drafts to a publication)

Briefly list the changes made to the code:

1. Added new project-publication-view page with a Document Tracker tab that shows a table of story drafts
2. Added new-story-draft-modal component for uploading story drafts with fields for author first name, last name, name in book, class period, and document link (based on create-publication-modal design for now)
3. Updated router to point the projects publication route to the new page

### ✔️ Verification

<img width="1642" height="892" alt="Screenshot 2026-04-09 at 11 41 52 AM" src="https://github.com/user-attachments/assets/cab85268-1941-4dba-8894-154bc5ad770f" />

<img width="1642" height="892" alt="Screenshot 2026-04-09 at 11 42 25 AM" src="https://github.com/user-attachments/assets/7274ed87-6b27-4f30-88af-bc0733b06888" />

### 🏕️ (Optional) Future Work / Notes