### PR TITLE
Create Story Draft modal wired to backend

### DIFF
--- a/apps/backend/src/author/author.service.ts
+++ b/apps/backend/src/author/author.service.ts
@@ -14,6 +14,8 @@ export class AuthorService {
     const author = await this.repo.create({
       id: id,
       name: createAuthorDto.name,
+      nameInBook: createAuthorDto.nameInBook,
+      classPeriod: createAuthorDto.classPeriod,
       bio: createAuthorDto.bio,
       grade: createAuthorDto.grade,
     });

--- a/apps/backend/src/author/dtos/create-author.dto.ts
+++ b/apps/backend/src/author/dtos/create-author.dto.ts
@@ -1,16 +1,28 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class CreateAuthorDto {
   @ApiProperty({ description: 'Name of author' })
   @IsString()
   name: string;
 
-  @ApiProperty({ description: 'Bio of author' })
+  @ApiPropertyOptional({ description: 'Name as it appears in the book' })
   @IsString()
-  bio: string;
+  @IsOptional()
+  nameInBook?: string;
 
-  @ApiProperty({ description: 'Grade of author' })
+  @ApiPropertyOptional({ description: 'Class period of the author' })
+  @IsString()
+  @IsOptional()
+  classPeriod?: string;
+
+  @ApiPropertyOptional({ description: 'Bio of author' })
+  @IsString()
+  @IsOptional()
+  bio?: string;
+
+  @ApiPropertyOptional({ description: 'Grade of author' })
   @IsNumber()
-  grade: number;
+  @IsOptional()
+  grade?: number;
 }

--- a/apps/backend/src/migrations/1776029357853-InitSchema.ts
+++ b/apps/backend/src/migrations/1776029357853-InitSchema.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitSchema1776029357853 implements MigrationInterface {
+  name = 'InitSchema1776029357853';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "storydrafts" ADD "anthologyId" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "role" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anthologys" ALTER COLUMN "publishedDate" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "anthologys" ALTER COLUMN "publishedDate" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "role" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "storydrafts" DROP COLUMN "anthologyId"`,
+    );
+  }
+}

--- a/apps/backend/src/story-draft/dto/create-story-draft.dto.ts
+++ b/apps/backend/src/story-draft/dto/create-story-draft.dto.ts
@@ -1,5 +1,12 @@
-import { IsString, IsInt, IsBoolean, IsEnum, IsArray } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsInt,
+  IsBoolean,
+  IsEnum,
+  IsArray,
+  IsOptional,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SubmissionRound, EditRound } from '../types';
 
 export class CreateStoryDraftDto {
@@ -11,36 +18,47 @@ export class CreateStoryDraftDto {
   @IsString()
   docLink: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Submission round',
     enum: SubmissionRound,
     example: SubmissionRound.ONE,
   })
   @IsEnum(SubmissionRound)
-  submissionRound: SubmissionRound;
+  @IsOptional()
+  submissionRound?: SubmissionRound;
 
-  @ApiProperty({ description: 'Whether the student has given consent' })
+  @ApiPropertyOptional({ description: 'Whether the student has given consent' })
   @IsBoolean()
-  studentConsent: boolean;
+  @IsOptional()
+  studentConsent?: boolean;
 
-  @ApiProperty({ description: 'Whether the story is in the manuscript' })
+  @ApiPropertyOptional({
+    description: 'Whether the story is in the manuscript',
+  })
   @IsBoolean()
-  inManuscript: boolean;
+  @IsOptional()
+  inManuscript?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Edit round',
     enum: EditRound,
     example: EditRound.ONE,
   })
   @IsEnum(EditRound)
-  editRound: EditRound;
+  @IsOptional()
+  editRound?: EditRound;
 
-  @ApiProperty({ description: 'Whether the story has been proofread' })
+  @ApiPropertyOptional({ description: 'Whether the story has been proofread' })
   @IsBoolean()
-  proofread: boolean;
+  @IsOptional()
+  proofread?: boolean;
 
-  @ApiProperty({ description: 'Notes about the story draft', type: [String] })
+  @ApiPropertyOptional({
+    description: 'Notes about the story draft',
+    type: [String],
+  })
   @IsArray()
   @IsString({ each: true })
-  notes: string[];
+  @IsOptional()
+  notes?: string[];
 }

--- a/apps/backend/src/story-draft/dto/create-story-draft.dto.ts
+++ b/apps/backend/src/story-draft/dto/create-story-draft.dto.ts
@@ -14,6 +14,10 @@ export class CreateStoryDraftDto {
   @IsInt()
   authorId: number;
 
+  @ApiProperty({ description: 'ID of the anthology' })
+  @IsInt()
+  anthologyId: number;
+
   @ApiProperty({ description: 'Link to the document' })
   @IsString()
   docLink: string;

--- a/apps/backend/src/story-draft/story-draft.controller.ts
+++ b/apps/backend/src/story-draft/story-draft.controller.ts
@@ -39,6 +39,7 @@ export class StoryDraftController {
       createStoryDraftDto.editRound ?? EditRound.ONE,
       createStoryDraftDto.proofread ?? false,
       createStoryDraftDto.notes ?? [],
+      createStoryDraftDto.anthologyId,
     );
     return { message: 'StoryDraft created successfully' };
   }
@@ -70,5 +71,12 @@ export class StoryDraftController {
   ): Promise<{ message: string }> {
     await this.storyDraftService.remove(storyDraftId);
     return { message: 'StoryDraft deleted successfully' };
+  }
+
+  @Get('/anthology/:anthologyId')
+  async getStoryDraftsByAnthology(
+    @Param('anthologyId', ParseIntPipe) anthologyId: number,
+  ) {
+    return this.storyDraftService.findByAnthology(anthologyId);
   }
 }

--- a/apps/backend/src/story-draft/story-draft.controller.ts
+++ b/apps/backend/src/story-draft/story-draft.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Delete,
+  Get,
   Param,
   ParseIntPipe,
   UseGuards,
@@ -20,6 +21,11 @@ import { EditRound, SubmissionRound } from './types';
 export class StoryDraftController {
   constructor(private readonly storyDraftService: StoryDraftService) {}
 
+  @Get()
+  async getStoryDrafts() {
+    return this.storyDraftService.findAll();
+  }
+
   @Post()
   async createStoryDraft(
     @Body() createStoryDraftDto: CreateStoryDraftDto,
@@ -27,12 +33,12 @@ export class StoryDraftController {
     await this.storyDraftService.create(
       createStoryDraftDto.authorId,
       createStoryDraftDto.docLink,
-      createStoryDraftDto.submissionRound,
-      createStoryDraftDto.studentConsent,
-      createStoryDraftDto.inManuscript,
-      createStoryDraftDto.editRound,
-      createStoryDraftDto.proofread,
-      createStoryDraftDto.notes,
+      createStoryDraftDto.submissionRound ?? SubmissionRound.ONE,
+      createStoryDraftDto.studentConsent ?? false,
+      createStoryDraftDto.inManuscript ?? false,
+      createStoryDraftDto.editRound ?? EditRound.ONE,
+      createStoryDraftDto.proofread ?? false,
+      createStoryDraftDto.notes ?? [],
     );
     return { message: 'StoryDraft created successfully' };
   }

--- a/apps/backend/src/story-draft/story-draft.entity.ts
+++ b/apps/backend/src/story-draft/story-draft.entity.ts
@@ -9,6 +9,9 @@ export class StoryDraft {
   @Column({ type: 'int' })
   authorId: number;
 
+  @Column({ type: 'int' })
+  anthologyId: number;
+
   @Column()
   docLink: string;
 

--- a/apps/backend/src/story-draft/story-draft.service.ts
+++ b/apps/backend/src/story-draft/story-draft.service.ts
@@ -22,6 +22,7 @@ export class StoryDraftService {
     editRound: EditRound,
     proofread: boolean,
     notes: string[],
+    anthologyId: number, // add this
   ) {
     const author = await this.authorRepo.findOne({ where: { id: authorId } });
     if (!author) {
@@ -37,6 +38,7 @@ export class StoryDraftService {
       editRound,
       proofread,
       notes,
+      anthologyId,
     });
 
     return await this.repo.save(storyDraft);
@@ -97,5 +99,9 @@ export class StoryDraftService {
     }
 
     return this.repo.remove(storyDraft);
+  }
+
+  async findByAnthology(anthologyId: number) {
+    return this.repo.findBy({ anthologyId });
   }
 }

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -69,12 +69,15 @@ export class ApiClient {
     return this.post('/api/author/author', body) as Promise<Author>;
   }
 
-  public async getStoryDrafts(): Promise<StoryDraft[]> {
-    return this.get('/api/story-drafts') as Promise<StoryDraft[]>;
+  public async getStoryDrafts(anthologyId: number) {
+    return this.get(`/api/story-drafts/anthology/${anthologyId}`) as Promise<
+      StoryDraft[]
+    >;
   }
 
   public async createStoryDraft(body: {
     authorId: number;
+    anthologyId: number;
     docLink: string;
   }): Promise<{ message: string }> {
     return this.post('/api/story-drafts', body) as Promise<{

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosInstance } from 'axios';
 import { fetchAuthSession } from 'aws-amplify/auth';
-import { Anthology, Story } from '../types';
+import { Anthology, Author, Story, StoryDraft } from '../types';
 import User from './dtos/user.dto';
 
 export interface FilterSortAnthologyBody {
@@ -55,6 +55,31 @@ export class ApiClient {
     return this.post('/api/anthologies/filter-sort', body) as Promise<
       Anthology[]
     >;
+  }
+
+  public async getAuthors(): Promise<Author[]> {
+    return this.get('/api/author/author') as Promise<Author[]>;
+  }
+
+  public async createAuthor(body: {
+    name: string;
+    nameInBook?: string;
+    classPeriod?: string;
+  }): Promise<Author> {
+    return this.post('/api/author/author', body) as Promise<Author>;
+  }
+
+  public async getStoryDrafts(): Promise<StoryDraft[]> {
+    return this.get('/api/story-drafts') as Promise<StoryDraft[]>;
+  }
+
+  public async createStoryDraft(body: {
+    authorId: number;
+    docLink: string;
+  }): Promise<{ message: string }> {
+    return this.post('/api/story-drafts', body) as Promise<{
+      message: string;
+    }>;
   }
 
   private async getAuthHeaders(): Promise<Record<string, string>> {

--- a/apps/frontend/src/containers/archived-publications/individual-publication/publication-view.tsx
+++ b/apps/frontend/src/containers/archived-publications/individual-publication/publication-view.tsx
@@ -261,27 +261,27 @@ const PublicationView: React.FC = () => {
     },
   ];
 
-  const productionDetails = [
-    { label: 'Foreword Author', value: anthology.foreword_author || 'Empty' },
-    { label: 'Age Category', value: anthology.age_category || 'Empty' },
-    { label: 'Pub Level', value: anthology.pub_level || 'Empty' },
-    {
-      label: 'Pub Date',
-      value: anthology.published_year?.toString() || 'Empty',
-    },
-    { label: 'ISBN', value: anthology.isbn || 'Empty' },
-    { label: 'Dimensions', value: anthology.dimensions || 'Empty' },
-    { label: 'Binding Type', value: anthology.binding_type || 'Empty' },
-    { label: 'Page Count', value: anthology.page_count?.toString() || 'Empty' },
-    { label: 'Print Run', value: anthology.print_run?.toString() || 'Empty' },
-    { label: 'Printed By', value: anthology.printed_by || 'Empty' },
-    {
-      label: 'Number of Students',
-      value: anthology.number_of_students?.toString() || 'Empty',
-    },
-    { label: 'Printing Cost', value: anthology.printing_cost || 'Empty' },
-    { label: 'Weight', value: anthology.weight || 'Empty' },
-  ];
+  // const productionDetails = [
+  //   { label: 'Foreword Author', value: anthology.foreword_author || 'Empty' },
+  //   { label: 'Age Category', value: anthology.age_category || 'Empty' },
+  //   { label: 'Pub Level', value: anthology.pub_level || 'Empty' },
+  //   {
+  //     label: 'Pub Date',
+  //     value: anthology.published_year?.toString() || 'Empty',
+  //   },
+  //   { label: 'ISBN', value: anthology.isbn || 'Empty' },
+  //   { label: 'Dimensions', value: anthology.dimensions || 'Empty' },
+  //   { label: 'Binding Type', value: anthology.binding_type || 'Empty' },
+  //   { label: 'Page Count', value: anthology.page_count?.toString() || 'Empty' },
+  //   { label: 'Print Run', value: anthology.print_run?.toString() || 'Empty' },
+  //   { label: 'Printed By', value: anthology.printed_by || 'Empty' },
+  //   {
+  //     label: 'Number of Students',
+  //     value: anthology.number_of_students?.toString() || 'Empty',
+  //   },
+  //   { label: 'Printing Cost', value: anthology.printing_cost || 'Empty' },
+  //   { label: 'Weight', value: anthology.weight || 'Empty' },
+  // ];
 
   const inventoryItems = [
     { label: 'Total Inventory', value: anthology.inventory?.toString() || '0' },
@@ -420,12 +420,12 @@ const PublicationView: React.FC = () => {
             activeTab={activeTab}
             onClick={setActiveTab}
           />
-          <TabButton
+          {/* <TabButton
             id="production-details"
             label="Production Details"
             activeTab={activeTab}
             onClick={setActiveTab}
-          />
+          /> */}
           <TabButton
             id="inventory"
             label="Inventory"
@@ -482,7 +482,7 @@ const PublicationView: React.FC = () => {
           </div>
         )}
 
-        {activeTab === 'production-details' && (
+        {/* {activeTab === 'production-details' && (
           <div className="tab-content">
             <DetailRowStatus />
             <DetailRowSponsors />
@@ -494,7 +494,7 @@ const PublicationView: React.FC = () => {
               />
             ))}
           </div>
-        )}
+        )} */}
 
         {activeTab === 'inventory' && (
           <div className="tab-content">

--- a/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
+++ b/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
@@ -1,15 +1,10 @@
 import { useState } from 'react';
 import '../../containers/create-publication-modal/styles.css';
+import apiClient from '../../api/apiClient';
 
 interface Props {
   onClose: () => void;
-  onSave: (draft: {
-    firstName: string;
-    lastName: string;
-    nameInBook: string;
-    classPeriod: string;
-    docLink: string;
-  }) => void;
+  onSaved: () => void;
 }
 
 interface FieldProps {
@@ -29,25 +24,44 @@ function Field({ label, required = false, children }: FieldProps) {
   );
 }
 
-export default function NewStoryDraftModal({ onClose, onSave }: Props) {
+export default function NewStoryDraftModal({ onClose, onSaved }: Props) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [nameInBook, setNameInBook] = useState('');
   const [classPeriod, setClassPeriod] = useState('');
   const [docLink, setDocLink] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const isValid = firstName.trim() && lastName.trim() && docLink.trim();
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!isValid) return;
-    onSave({
-      firstName: firstName.trim(),
-      lastName: lastName.trim(),
-      nameInBook,
-      classPeriod,
-      docLink,
-    });
-    onClose();
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const author = await apiClient.createAuthor({
+        name: `${firstName.trim()} ${lastName.trim()}`,
+        nameInBook: nameInBook || undefined,
+        classPeriod: classPeriod || undefined,
+      });
+
+      await apiClient.createStoryDraft({
+        authorId: author.id,
+        docLink: docLink.trim(),
+      });
+
+      onSaved();
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to create story draft.';
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -56,18 +70,27 @@ export default function NewStoryDraftModal({ onClose, onSave }: Props) {
         <div className="modal__header">
           <div className="modal__header-row">
             <h1 className="modal__title">New Story Draft</h1>
-            <button className="modal__close" onClick={onClose}>×</button>
+            <button className="modal__close" onClick={onClose}>
+              ×
+            </button>
           </div>
         </div>
 
         <div className="modal__body">
+          {error && (
+            <div className="field" style={{ color: 'var(--error, #d32f2f)' }}>
+              {error}
+            </div>
+          )}
+
           <div className="field-row">
             <Field label="First Name" required>
               <input
                 className="input"
                 placeholder="Author's first name"
                 value={firstName}
-                onChange={e => setFirstName(e.target.value)}
+                onChange={(e) => setFirstName(e.target.value)}
+                disabled={saving}
               />
             </Field>
             <Field label="Last Name" required>
@@ -75,7 +98,8 @@ export default function NewStoryDraftModal({ onClose, onSave }: Props) {
                 className="input"
                 placeholder="Author's last name"
                 value={lastName}
-                onChange={e => setLastName(e.target.value)}
+                onChange={(e) => setLastName(e.target.value)}
+                disabled={saving}
               />
             </Field>
           </div>
@@ -85,7 +109,8 @@ export default function NewStoryDraftModal({ onClose, onSave }: Props) {
               className="input"
               placeholder="Author's name as it appears in the book"
               value={nameInBook}
-              onChange={e => setNameInBook(e.target.value)}
+              onChange={(e) => setNameInBook(e.target.value)}
+              disabled={saving}
             />
           </Field>
 
@@ -94,7 +119,8 @@ export default function NewStoryDraftModal({ onClose, onSave }: Props) {
               className="input"
               placeholder="e.g. Edwards 1/6"
               value={classPeriod}
-              onChange={e => setClassPeriod(e.target.value)}
+              onChange={(e) => setClassPeriod(e.target.value)}
+              disabled={saving}
             />
           </Field>
 
@@ -103,20 +129,27 @@ export default function NewStoryDraftModal({ onClose, onSave }: Props) {
               className="input"
               placeholder="Paste Google Doc or Drive link"
               value={docLink}
-              onChange={e => setDocLink(e.target.value)}
+              onChange={(e) => setDocLink(e.target.value)}
+              disabled={saving}
             />
           </Field>
         </div>
 
         <div className="modal__footer">
           <div className="modal__footer-right">
-            <button className="btn btn--secondary" onClick={onClose}>Cancel</button>
+            <button
+              className="btn btn--secondary"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
             <button
               className="btn btn--primary"
               onClick={handleSave}
-              disabled={!isValid}
+              disabled={!isValid || saving}
             >
-              Save
+              {saving ? 'Saving...' : 'Save'}
             </button>
           </div>
         </div>

--- a/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
+++ b/apps/frontend/src/containers/projects-publication/new-story-draft-modal.tsx
@@ -3,6 +3,7 @@ import '../../containers/create-publication-modal/styles.css';
 import apiClient from '../../api/apiClient';
 
 interface Props {
+  anthologyId: number;
   onClose: () => void;
   onSaved: () => void;
 }
@@ -24,7 +25,11 @@ function Field({ label, required = false, children }: FieldProps) {
   );
 }
 
-export default function NewStoryDraftModal({ onClose, onSaved }: Props) {
+export default function NewStoryDraftModal({
+  anthologyId,
+  onClose,
+  onSaved,
+}: Props) {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [nameInBook, setNameInBook] = useState('');
@@ -50,6 +55,7 @@ export default function NewStoryDraftModal({ onClose, onSaved }: Props) {
 
       await apiClient.createStoryDraft({
         authorId: author.id,
+        anthologyId: anthologyId,
         docLink: docLink.trim(),
       });
 

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import apiClient from '../../api/apiClient';
-import { Anthology } from '../../types';
+import { Anthology, Author } from '../../types';
 import NewStoryDraftModal from './new-story-draft-modal';
 import './project-publication-view.css';
 
@@ -20,21 +20,62 @@ const ProjectPublicationView: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [storyDrafts, setStoryDrafts] = useState<StoryDraftRow[]>([]);
 
+  const loadStoryDrafts = useCallback(async () => {
+    try {
+      const [drafts, authors] = await Promise.all([
+        apiClient.getStoryDrafts(),
+        apiClient.getAuthors(),
+      ]);
+
+      const authorMap = new Map<number, Author>();
+      for (const author of authors) {
+        authorMap.set(author.id, author);
+      }
+
+      setStoryDrafts(
+        drafts.map((draft) => {
+          const author = authorMap.get(draft.authorId);
+          const nameParts = author?.name?.split(' ') ?? [];
+          return {
+            firstName: nameParts[0] ?? '',
+            lastName: nameParts.slice(1).join(' '),
+            nameInBook: author?.nameInBook ?? '',
+            classPeriod: author?.classPeriod ?? '',
+            docLink: draft.docLink,
+          };
+        }),
+      );
+    } catch {
+      // Story drafts will remain as-is on fetch failure
+    }
+  }, []);
+
   useEffect(() => {
     if (id) {
-      apiClient.getAnthology(id)
-        .then((data) => { setAnthology(data); setLoading(false); })
+      apiClient
+        .getAnthology(id)
+        .then((data) => {
+          setAnthology(data);
+          setLoading(false);
+        })
         .catch(() => setLoading(false));
     }
   }, [id]);
 
+  useEffect(() => {
+    loadStoryDrafts();
+  }, [loadStoryDrafts]);
+
   if (loading) return <div className="ppv-wrapper">Loading...</div>;
-  if (!anthology) return <div className="ppv-wrapper">No publication found.</div>;
+  if (!anthology)
+    return <div className="ppv-wrapper">No publication found.</div>;
 
   return (
     <div className="ppv-wrapper">
       <div className="ppv-breadcrumb">
-        <a href="/projects/drafts" className="ppv-breadcrumb-link">Projects</a>
+        <a href="/projects/drafts" className="ppv-breadcrumb-link">
+          Projects
+        </a>
         <span className="ppv-breadcrumb-sep">›</span>
         <span>{anthology.title}</span>
       </div>
@@ -43,7 +84,9 @@ const ProjectPublicationView: React.FC = () => {
         <h1 className="ppv-title">{anthology.title}</h1>
 
         <div className="publication-tabs">
-          <span className="publication-tab publication-tab--active">Document Tracker</span>
+          <span className="publication-tab publication-tab--active">
+            Document Tracker
+          </span>
         </div>
 
         <div className="ppv-tab-content">
@@ -70,7 +113,14 @@ const ProjectPublicationView: React.FC = () => {
             <tbody>
               {storyDrafts.length === 0 ? (
                 <tr>
-                  <td colSpan={5} style={{ textAlign: 'center', color: 'var(--neutral-400)', padding: '24px' }}>
+                  <td
+                    colSpan={5}
+                    style={{
+                      textAlign: 'center',
+                      color: 'var(--neutral-400)',
+                      padding: '24px',
+                    }}
+                  >
                     No story drafts yet.
                   </td>
                 </tr>
@@ -81,7 +131,11 @@ const ProjectPublicationView: React.FC = () => {
                     <td>{draft.lastName}</td>
                     <td>{draft.nameInBook}</td>
                     <td>{draft.classPeriod}</td>
-                    <td><a href={draft.docLink} target="_blank" rel="noreferrer">Open</a></td>
+                    <td>
+                      <a href={draft.docLink} target="_blank" rel="noreferrer">
+                        Open
+                      </a>
+                    </td>
                   </tr>
                 ))
               )}
@@ -93,7 +147,7 @@ const ProjectPublicationView: React.FC = () => {
       {isModalOpen && (
         <NewStoryDraftModal
           onClose={() => setIsModalOpen(false)}
-          onSave={(draft) => setStoryDrafts((prev) => [...prev, draft])}
+          onSaved={loadStoryDrafts}
         />
       )}
     </div>

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
@@ -21,9 +21,10 @@ const ProjectPublicationView: React.FC = () => {
   const [storyDrafts, setStoryDrafts] = useState<StoryDraftRow[]>([]);
 
   const loadStoryDrafts = useCallback(async () => {
+    if (!id) return;
     try {
       const [drafts, authors] = await Promise.all([
-        apiClient.getStoryDrafts(),
+        apiClient.getStoryDrafts(Number(id)),
         apiClient.getAuthors(),
       ]);
 
@@ -146,6 +147,7 @@ const ProjectPublicationView: React.FC = () => {
 
       {isModalOpen && (
         <NewStoryDraftModal
+          anthologyId={anthology.id}
           onClose={() => setIsModalOpen(false)}
           onSaved={loadStoryDrafts}
         />

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -17,8 +17,16 @@ export enum AnthologyPubLevel {
 export interface Author {
   id: number;
   name: string;
+  nameInBook?: string;
+  classPeriod?: string;
   bio?: string;
   grade?: number;
+}
+
+export interface StoryDraft {
+  id: number;
+  authorId: number;
+  docLink: string;
 }
 
 export interface Story {


### PR DESCRIPTION
### ℹ️ Issue 150

Closes #150 

## Summary
Wires up the `NewStoryDraftModal` to create an author and story draft via the API, replacing the previous local-only state management.


## How it works
1. User fills in the modal and clicks Save.
2. Frontend calls `POST /api/author/author` with `name`, `nameInBook`, and `classPeriod`.
3. On success, the returned `authorId` is used to call `POST /api/story-drafts` with the doc link.
4. On success, the modal closes and the story draft list refreshes from the API.
5. On failure, an error message is shown inline in the modal.
