### PR TITLE
new edit story draft modal + change db migration

### DIFF
--- a/apps/backend/src/author/dtos/edit-author.dto.ts
+++ b/apps/backend/src/author/dtos/edit-author.dto.ts
@@ -7,6 +7,16 @@ export class EditAuthorDto {
   @IsOptional()
   name?: string;
 
+  @ApiProperty({ description: 'Name as it appears in the book' })
+  @IsString()
+  @IsOptional()
+  nameInBook?: string;
+
+  @ApiProperty({ description: 'Class period of the author' })
+  @IsString()
+  @IsOptional()
+  classPeriod?: string;
+
   @ApiProperty({ description: 'Bio of author' })
   @IsString()
   @IsOptional()

--- a/apps/backend/src/migrations/1776029357853-InitSchema.ts
+++ b/apps/backend/src/migrations/1776029357853-InitSchema.ts
@@ -5,7 +5,13 @@ export class InitSchema1776029357853 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "storydrafts" ADD "anthologyId" integer NOT NULL`,
+      `ALTER TABLE "storydrafts" ADD "anthologyId" integer`,
+    );
+    await queryRunner.query(
+      `UPDATE "storydrafts" SET "anthologyId" = 0 WHERE "anthologyId" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "storydrafts" ALTER COLUMN "anthologyId" SET NOT NULL`,
     );
     await queryRunner.query(
       `ALTER TABLE "users" ALTER COLUMN "role" SET NOT NULL`,

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -1,6 +1,13 @@
 import axios, { type AxiosInstance } from 'axios';
 import { fetchAuthSession } from 'aws-amplify/auth';
-import { Anthology, Author, Story, StoryDraft } from '../types';
+import {
+  Anthology,
+  Author,
+  EditRound,
+  Story,
+  StoryDraft,
+  SubmissionRound,
+} from '../types';
 import User from './dtos/user.dto';
 
 export interface FilterSortAnthologyBody {
@@ -85,6 +92,34 @@ export class ApiClient {
     }>;
   }
 
+  public async updateAuthor(
+    authorId: number,
+    body: {
+      name?: string;
+      nameInBook?: string;
+      classPeriod?: string;
+    },
+  ): Promise<Author> {
+    return this.put(`/api/author/author/${authorId}`, body) as Promise<Author>;
+  }
+
+  public async updateStoryDraft(
+    storyDraftId: number,
+    body: {
+      docLink?: string;
+      submissionRound?: SubmissionRound;
+      studentConsent?: boolean;
+      inManuscript?: boolean;
+      editRound?: EditRound;
+      proofread?: boolean;
+      notes?: string[];
+    },
+  ): Promise<{ message: string }> {
+    return this.post(`/api/story-drafts/${storyDraftId}`, body) as Promise<{
+      message: string;
+    }>;
+  }
+
   private async getAuthHeaders(): Promise<Record<string, string>> {
     try {
       const session = await fetchAuthSession();
@@ -107,6 +142,13 @@ export class ApiClient {
     const headers = await this.getAuthHeaders();
     return this.axiosInstance
       .post(path, body, { headers })
+      .then((response) => response.data);
+  }
+
+  private async put(path: string, body: unknown): Promise<unknown> {
+    const headers = await this.getAuthHeaders();
+    return this.axiosInstance
+      .put(path, body, { headers })
       .then((response) => response.data);
   }
 

--- a/apps/frontend/src/containers/create-publication-modal/styles.css
+++ b/apps/frontend/src/containers/create-publication-modal/styles.css
@@ -275,3 +275,29 @@
   font-weight: 600;
   font-size: 16px;
 }
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  user-select: none;
+}
+
+.toggle-label input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #E85100;
+}
+
+.bool-yes {
+  color: #16a34a;
+  font-weight: 600;
+}
+
+.bool-no {
+  color: #dc2626;
+  font-weight: 600;
+}

--- a/apps/frontend/src/containers/projects-publication/edit-story-draft-modal.tsx
+++ b/apps/frontend/src/containers/projects-publication/edit-story-draft-modal.tsx
@@ -1,0 +1,290 @@
+import { useState } from 'react';
+import '../../containers/create-publication-modal/styles.css';
+import apiClient from '../../api/apiClient';
+import { SubmissionRound, EditRound } from '../../types';
+
+export interface EditableStoryDraft {
+  storyDraftId: number;
+  authorId: number;
+  firstName: string;
+  lastName: string;
+  nameInBook: string;
+  classPeriod: string;
+  docLink: string;
+  submissionRound: SubmissionRound;
+  studentConsent: boolean;
+  inManuscript: boolean;
+  editRound: EditRound;
+  proofread: boolean;
+  notes: string[];
+}
+
+interface Props {
+  draft: EditableStoryDraft;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface FieldProps {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+function Field({ label, required = false, children }: FieldProps) {
+  return (
+    <div className="field">
+      <label className="field__label">
+        {label} {required && <span className="field__required">*</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+const SUBMISSION_ROUND_LABELS: Record<SubmissionRound, string> = {
+  [SubmissionRound.ONE]: 'Round 1',
+  [SubmissionRound.TWO]: 'Round 2',
+  [SubmissionRound.THREE]: 'Round 3',
+};
+
+const EDIT_ROUND_LABELS: Record<EditRound, string> = {
+  [EditRound.ONE]: 'Round 1',
+  [EditRound.TWO]: 'Round 2',
+};
+
+export default function EditStoryDraftModal({
+  draft,
+  onClose,
+  onSaved,
+}: Props) {
+  const [firstName, setFirstName] = useState(draft.firstName);
+  const [lastName, setLastName] = useState(draft.lastName);
+  const [nameInBook, setNameInBook] = useState(draft.nameInBook);
+  const [classPeriod, setClassPeriod] = useState(draft.classPeriod);
+  const [docLink, setDocLink] = useState(draft.docLink);
+  const [submissionRound, setSubmissionRound] = useState(draft.submissionRound);
+  const [studentConsent, setStudentConsent] = useState(draft.studentConsent);
+  const [inManuscript, setInManuscript] = useState(draft.inManuscript);
+  const [editRound, setEditRound] = useState(draft.editRound);
+  const [proofread, setProofread] = useState(draft.proofread);
+  const [notes, setNotes] = useState(draft.notes.join('\n'));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isValid = firstName.trim() && lastName.trim() && docLink.trim();
+
+  const handleSave = async () => {
+    if (!isValid) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      await Promise.all([
+        apiClient.updateAuthor(draft.authorId, {
+          name: `${firstName.trim()} ${lastName.trim()}`,
+          nameInBook: nameInBook || undefined,
+          classPeriod: classPeriod || undefined,
+        }),
+        apiClient.updateStoryDraft(draft.storyDraftId, {
+          docLink: docLink.trim(),
+          submissionRound,
+          studentConsent,
+          inManuscript,
+          editRound,
+          proofread,
+          notes: notes
+            .split('\n')
+            .map((n) => n.trim())
+            .filter(Boolean),
+        }),
+      ]);
+
+      onSaved();
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to update story draft.';
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <div className="modal__header">
+          <div className="modal__header-row">
+            <h1 className="modal__title">Edit Story Draft</h1>
+            <button className="modal__close" onClick={onClose}>
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div className="modal__body">
+          {error && (
+            <div className="field" style={{ color: 'var(--error, #d32f2f)' }}>
+              {error}
+            </div>
+          )}
+
+          <div className="field-row">
+            <Field label="First Name" required>
+              <input
+                className="input"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                disabled={saving}
+              />
+            </Field>
+            <Field label="Last Name" required>
+              <input
+                className="input"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                disabled={saving}
+              />
+            </Field>
+          </div>
+
+          <Field label="Name in Book">
+            <input
+              className="input"
+              value={nameInBook}
+              onChange={(e) => setNameInBook(e.target.value)}
+              disabled={saving}
+            />
+          </Field>
+
+          <Field label="Class Period">
+            <input
+              className="input"
+              value={classPeriod}
+              onChange={(e) => setClassPeriod(e.target.value)}
+              disabled={saving}
+            />
+          </Field>
+
+          <Field label="Document Link" required>
+            <input
+              className="input"
+              value={docLink}
+              onChange={(e) => setDocLink(e.target.value)}
+              disabled={saving}
+            />
+          </Field>
+
+          <div className="field-row">
+            <Field label="Submission Round">
+              <select
+                className="input"
+                value={submissionRound}
+                onChange={(e) =>
+                  setSubmissionRound(Number(e.target.value) as SubmissionRound)
+                }
+                disabled={saving}
+              >
+                {Object.entries(SUBMISSION_ROUND_LABELS).map(([val, label]) => (
+                  <option key={val} value={val}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Edit Round">
+              <select
+                className="input"
+                value={editRound}
+                onChange={(e) =>
+                  setEditRound(Number(e.target.value) as EditRound)
+                }
+                disabled={saving}
+              >
+                {Object.entries(EDIT_ROUND_LABELS).map(([val, label]) => (
+                  <option key={val} value={val}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div className="field-row">
+            <Field label="Student Consent">
+              <label className="toggle-label">
+                <input
+                  type="checkbox"
+                  checked={studentConsent}
+                  onChange={(e) => setStudentConsent(e.target.checked)}
+                  disabled={saving}
+                />
+                <span className={studentConsent ? 'bool-yes' : 'bool-no'}>
+                  {studentConsent ? '✓ Yes' : '✗ No'}
+                </span>
+              </label>
+            </Field>
+            <Field label="In Manuscript">
+              <label className="toggle-label">
+                <input
+                  type="checkbox"
+                  checked={inManuscript}
+                  onChange={(e) => setInManuscript(e.target.checked)}
+                  disabled={saving}
+                />
+                <span className={inManuscript ? 'bool-yes' : 'bool-no'}>
+                  {inManuscript ? '✓ Yes' : '✗ No'}
+                </span>
+              </label>
+            </Field>
+            <Field label="Proofread">
+              <label className="toggle-label">
+                <input
+                  type="checkbox"
+                  checked={proofread}
+                  onChange={(e) => setProofread(e.target.checked)}
+                  disabled={saving}
+                />
+                <span className={proofread ? 'bool-yes' : 'bool-no'}>
+                  {proofread ? '✓ Yes' : '✗ No'}
+                </span>
+              </label>
+            </Field>
+          </div>
+
+          <Field label="Notes">
+            <textarea
+              className="input input--textarea"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={saving}
+              placeholder="One note per line"
+              rows={4}
+            />
+          </Field>
+        </div>
+
+        <div className="modal__footer">
+          <div className="modal__footer-right">
+            <button
+              className="btn btn--secondary"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              className="btn btn--primary"
+              onClick={handleSave}
+              disabled={!isValid || saving}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.css
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.css
@@ -73,6 +73,23 @@
   background-color: var(--neutral-200);
 }
 
+.document-tracker-edit-btn {
+  background: none;
+  border: 1px solid #E85100;
+  color: #E85100;
+  border-radius: 6px;
+  padding: 4px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-body);
+}
+
+.document-tracker-edit-btn:hover {
+  background: #E85100;
+  color: #fff;
+}
+
 .archive-modal-content input {
   display: block;
   width: 100%;

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
@@ -1,16 +1,27 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import apiClient from '../../api/apiClient';
-import { Anthology, Author } from '../../types';
+import { Anthology, Author, SubmissionRound, EditRound } from '../../types';
 import NewStoryDraftModal from './new-story-draft-modal';
+import EditStoryDraftModal, {
+  EditableStoryDraft,
+} from './edit-story-draft-modal';
 import './project-publication-view.css';
 
 interface StoryDraftRow {
+  storyDraftId: number;
+  authorId: number;
   firstName: string;
   lastName: string;
   nameInBook: string;
   classPeriod: string;
   docLink: string;
+  submissionRound: SubmissionRound;
+  studentConsent: boolean;
+  inManuscript: boolean;
+  editRound: EditRound;
+  proofread: boolean;
+  notes: string[];
 }
 
 const ProjectPublicationView: React.FC = () => {
@@ -18,6 +29,7 @@ const ProjectPublicationView: React.FC = () => {
   const [anthology, setAnthology] = useState<Anthology | null>(null);
   const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingDraft, setEditingDraft] = useState<StoryDraftRow | null>(null);
   const [storyDrafts, setStoryDrafts] = useState<StoryDraftRow[]>([]);
 
   const loadStoryDrafts = useCallback(async () => {
@@ -38,18 +50,26 @@ const ProjectPublicationView: React.FC = () => {
           const author = authorMap.get(draft.authorId);
           const nameParts = author?.name?.split(' ') ?? [];
           return {
+            storyDraftId: draft.id,
+            authorId: draft.authorId,
             firstName: nameParts[0] ?? '',
             lastName: nameParts.slice(1).join(' '),
             nameInBook: author?.nameInBook ?? '',
             classPeriod: author?.classPeriod ?? '',
             docLink: draft.docLink,
+            submissionRound: draft.submissionRound,
+            studentConsent: draft.studentConsent,
+            inManuscript: draft.inManuscript,
+            editRound: draft.editRound,
+            proofread: draft.proofread,
+            notes: draft.notes,
           };
         }),
       );
     } catch {
       // Story drafts will remain as-is on fetch failure
     }
-  }, []);
+  }, [id]);
 
   useEffect(() => {
     if (id) {
@@ -109,13 +129,14 @@ const ProjectPublicationView: React.FC = () => {
                 <th>Name in Book</th>
                 <th>Class Period</th>
                 <th>Document Link</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
               {storyDrafts.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={6}
                     style={{
                       textAlign: 'center',
                       color: 'var(--neutral-400)',
@@ -126,8 +147,8 @@ const ProjectPublicationView: React.FC = () => {
                   </td>
                 </tr>
               ) : (
-                storyDrafts.map((draft, i) => (
-                  <tr key={i}>
+                storyDrafts.map((draft) => (
+                  <tr key={draft.storyDraftId}>
                     <td>{draft.firstName}</td>
                     <td>{draft.lastName}</td>
                     <td>{draft.nameInBook}</td>
@@ -136,6 +157,15 @@ const ProjectPublicationView: React.FC = () => {
                       <a href={draft.docLink} target="_blank" rel="noreferrer">
                         Open
                       </a>
+                    </td>
+                    <td>
+                      <button
+                        type="button"
+                        className="document-tracker-edit-btn"
+                        onClick={() => setEditingDraft(draft)}
+                      >
+                        Edit
+                      </button>
                     </td>
                   </tr>
                 ))
@@ -149,6 +179,14 @@ const ProjectPublicationView: React.FC = () => {
         <NewStoryDraftModal
           anthologyId={anthology.id}
           onClose={() => setIsModalOpen(false)}
+          onSaved={loadStoryDrafts}
+        />
+      )}
+
+      {editingDraft && (
+        <EditStoryDraftModal
+          draft={editingDraft as EditableStoryDraft}
+          onClose={() => setEditingDraft(null)}
           onSaved={loadStoryDrafts}
         />
       )}

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -23,10 +23,27 @@ export interface Author {
   grade?: number;
 }
 
+export enum SubmissionRound {
+  ONE = 0,
+  TWO = 1,
+  THREE = 2,
+}
+
+export enum EditRound {
+  ONE = 0,
+  TWO = 1,
+}
+
 export interface StoryDraft {
   id: number;
   authorId: number;
   docLink: string;
+  submissionRound: SubmissionRound;
+  studentConsent: boolean;
+  inManuscript: boolean;
+  editRound: EditRound;
+  proofread: boolean;
+  notes: string[];
 }
 
 export interface Story {


### PR DESCRIPTION
# closes #152 

## Summary
Adds an Edit modal for story drafts that displays all fields (including submission round, student consent, in manuscript, edit round, proofread, and notes) and allows editing them.

## How to test
1. projects > open a publication 
2. each story draft row now has an edit button
3. Click Edit to open the modal;  all fields pre-populated  editable
4. Boolean fields (student consent, in manuscript, proofread) display as checkboxes with green/red indicators
5. Notes is a textarea (one note per line)
6. save

## Changes

**Backend**
- `EditAuthorDto` — added optional `nameInBook` and `classPeriod` fields
- `StoryDraft` frontend type — expanded to include all entity fields + `SubmissionRound`/`EditRound` enums
- `apiClient.ts` — added `updateAuthor()` and `updateStoryDraft()` methods

**Frontend**
- New `EditStoryDraftModal` component with all editable fields
- `ProjectPublicationView` — added Edit button column to the table, wired up the edit modal with list refresh on save

**CSS**
- Edit button styling (orange outline, fills on hover)
- Boolean toggle labels with green checkmark / red X

## Migration note
The `1776029357853-InitSchema` migration was updated to handle existing rows in `storydrafts`. It now adds `anthologyId` as nullable first, backfills existing rows with `0`, then sets `NOT NULL`. `yarn migration:run` 
