### PR TITLE
Omchai tab, individual project view page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Thumbs.db
 
 # Cache
 .nx/cache
+.nx/workspace-data

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ To run both the frontend and backend with one command:
 
 ```
 nx run-many -t serve -p frontend backend
-```
+```git
 
 
 ## Other commands
 
-Test new migrations with yarn db:reset
+Test new migrations and seed data with yarn db:reset. You may need to reconnect to the database in pgadmin to see the cahnges
 
 Run `git submodule update --remote` to pull the latest changes from the component library
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ To run both the frontend and backend with one command:
 nx run-many -t serve -p frontend backend
 ```
 
+
 ## Other commands
+
+Test new migrations with yarn db:reset
 
 Run `git submodule update --remote` to pull the latest changes from the component library
 

--- a/apps/backend/src/omchai/omchai.entity.ts
+++ b/apps/backend/src/omchai/omchai.entity.ts
@@ -39,10 +39,10 @@ export class Omchai {
   datetimeAssigned: Date;
 
   @ManyToOne(() => User, (user) => user.omchaiAssignments)
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({ name: 'userId' })
   user: Relation<User>;
 
   @ManyToOne(() => Anthology, (anthology) => anthology.omchaiAssignments)
-  @JoinColumn({ name: 'anthology_id' })
+  @JoinColumn({ name: 'anthologyId' })
   anthology: Relation<Anthology>;
 }

--- a/apps/backend/src/omchai/omchai.service.ts
+++ b/apps/backend/src/omchai/omchai.service.ts
@@ -19,7 +19,10 @@ export class OmchaiService {
   }
 
   findByAnthologyId(anthologyId: number) {
-    return this.repo.find({ where: { anthologyId: anthologyId } });
+    return this.repo.find({
+      where: { anthologyId },
+      relations: ['user'],
+    });
   }
 
   async update(id: number, updateOmchaiDto: EditOmchaiDto) {

--- a/apps/backend/src/seeds/omchai.seed.ts
+++ b/apps/backend/src/seeds/omchai.seed.ts
@@ -1,49 +1,103 @@
-import { time } from 'console';
-import { InventoryHolding } from 'src/inventory-holding/inventory-holding.entity';
 import { Omchai, OmchaiRole } from 'src/omchai/omchai.entity';
 import { DeepPartial } from 'typeorm';
 
 export const OmchaiSeed: DeepPartial<Omchai>[] = [
+  // Anthology 1
   {
-    id: 1,
     anthologyId: 1,
     userId: 1,
     role: OmchaiRole.OWNER,
     datetimeAssigned: new Date(),
   },
   {
-    id: 2,
     anthologyId: 1,
     userId: 2,
     role: OmchaiRole.MANAGER,
     datetimeAssigned: new Date(),
   },
-
   {
-    id: 3,
     anthologyId: 1,
     userId: 3,
     role: OmchaiRole.CONSULTED,
     datetimeAssigned: new Date(),
   },
   {
-    id: 4,
     anthologyId: 1,
     userId: 3,
     role: OmchaiRole.HELPER,
     datetimeAssigned: new Date(),
   },
   {
-    id: 5,
     anthologyId: 1,
     userId: 4,
     role: OmchaiRole.APPROVER,
     datetimeAssigned: new Date(),
   },
   {
-    id: 5,
     anthologyId: 1,
     userId: 6,
+    role: OmchaiRole.INFORMED,
+    datetimeAssigned: new Date(),
+  },
+
+  // Anthology 5 — full set of roles with multi-user entries
+  {
+    anthologyId: 5,
+    userId: 1,
+    role: OmchaiRole.OWNER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 3,
+    role: OmchaiRole.MANAGER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 6,
+    role: OmchaiRole.MANAGER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 4,
+    role: OmchaiRole.CONSULTED,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 5,
+    role: OmchaiRole.CONSULTED,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 7,
+    role: OmchaiRole.HELPER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 6,
+    role: OmchaiRole.HELPER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 2,
+    role: OmchaiRole.APPROVER,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 5,
+    role: OmchaiRole.INFORMED,
+    datetimeAssigned: new Date(),
+  },
+  {
+    anthologyId: 5,
+    userId: 1,
     role: OmchaiRole.INFORMED,
     datetimeAssigned: new Date(),
   },

--- a/apps/backend/src/seeds/seed-omchai.ts
+++ b/apps/backend/src/seeds/seed-omchai.ts
@@ -5,13 +5,14 @@ import { OmchaiSeed } from './omchai.seed';
 export async function seedOmchais(dataSource: DataSource) {
   const repository = dataSource.getRepository(Omchai);
 
-  console.log('Seeding inventory holdings...');
+  console.log('Seeding omchais...');
 
   for (const data of OmchaiSeed) {
     const exists = await repository.findOne({
       where: {
         userId: data.userId,
         anthologyId: data.anthologyId,
+        role: data.role,
       },
     });
 

--- a/apps/backend/src/seeds/users.seed.ts
+++ b/apps/backend/src/seeds/users.seed.ts
@@ -43,4 +43,20 @@ export const UsersSeed: DeepPartial<User>[] = [
     email: 'tony.king@gmail.com',
     title: 'Director of Communications',
   },
+  {
+    id: 6,
+    role: Role.STANDARD,
+    firstName: 'Sasha',
+    lastName: 'Nguyen',
+    email: 'sasha.nguyen@gmail.com',
+    title: 'Program Assistant',
+  },
+  {
+    id: 7,
+    role: Role.STANDARD,
+    firstName: 'Jamie',
+    lastName: 'Rivera',
+    email: 'jamie.rivera@gmail.com',
+    title: 'Publishing Fellow',
+  },
 ];

--- a/apps/backend/src/seeds/users.seed.ts
+++ b/apps/backend/src/seeds/users.seed.ts
@@ -59,4 +59,12 @@ export const UsersSeed: DeepPartial<User>[] = [
     email: 'jamie.rivera@gmail.com',
     title: 'Publishing Fellow',
   },
+  {
+    id: 8,
+    role: Role.ADMIN,
+    firstName: 'Gauri',
+    lastName: 'Rajesh',
+    email: 'gauri.ggsr@gmail.com',
+    title: 'Volunteer Assistant',
+  },
 ];

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosInstance } from 'axios';
 import { fetchAuthSession } from 'aws-amplify/auth';
-import { Anthology, Author, Story, StoryDraft } from '../types';
+import { Anthology, Author, OmchaiEntry, Story, StoryDraft } from '../types';
 import User from './dtos/user.dto';
 
 export interface FilterSortAnthologyBody {
@@ -83,6 +83,14 @@ export class ApiClient {
     return this.post('/api/story-drafts', body) as Promise<{
       message: string;
     }>;
+  }
+
+  public async getOmchaiByAnthology(
+    anthologyId: number,
+  ): Promise<OmchaiEntry[]> {
+    return this.get(`/api/omchai/anthology/${anthologyId}`) as Promise<
+      OmchaiEntry[]
+    >;
   }
 
   private async getAuthHeaders(): Promise<Record<string, string>> {

--- a/apps/frontend/src/containers/archived-publications/index.tsx
+++ b/apps/frontend/src/containers/archived-publications/index.tsx
@@ -149,20 +149,18 @@ export default function ArchivedPublications({
 
     if (mode === 'archive') {
       if (activeArchiveTab === 'published') {
-        return (
-          status === AnthologyStatus.CAN_BE_SHARED || status === 'Published'
-        );
+        return status === AnthologyStatus.PUBLISHED || status === 'Published';
       }
 
       return status === AnthologyStatus.ARCHIVED;
     }
 
     if (activeProjectTab === 'drafts') {
-      return pub.status === AnthologyStatus.NOT_STARTED;
+      return pub.status === AnthologyStatus.DRAFT;
     }
 
     if (activeProjectTab === 'in-revision') {
-      return pub.status === AnthologyStatus.DRAFTING;
+      return pub.status === AnthologyStatus.IN_REVISION;
     }
 
     if (activeProjectTab === 'in-production') {
@@ -170,7 +168,7 @@ export default function ArchivedPublications({
     }
 
     if (activeProjectTab === 'published') {
-      return status === AnthologyStatus.CAN_BE_SHARED || status === 'Published';
+      return status === AnthologyStatus.PUBLISHED || status === 'Published';
     }
 
     if (activeProjectTab === 'archived') {

--- a/apps/frontend/src/containers/projects-publication/omchai-view.css
+++ b/apps/frontend/src/containers/projects-publication/omchai-view.css
@@ -1,0 +1,104 @@
+.omchai-loading {
+  padding: 24px;
+  color: var(--neutral-400);
+  font-family: var(--font-body);
+}
+
+.omchai-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.omchai-card {
+  background: #fff;
+  border: 1px solid var(--neutral-300, #e5e0de);
+  border-radius: 10px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.omchai-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.omchai-card__title {
+  margin: 0;
+  font-family: var(--font-heading, 'Roboto', sans-serif);
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--neutral-600);
+}
+
+.omchai-card__toggle {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid var(--neutral-300, #e5e0de);
+  background: var(--neutral-100, #faf8f7);
+  color: var(--neutral-400, #9b9592);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.omchai-card__toggle:hover {
+  border-color: #E85100;
+  color: #E85100;
+  background: #fff;
+}
+
+.omchai-card__desc {
+  margin: 0;
+  font-family: var(--font-body, 'Open Sans', sans-serif);
+  font-size: 13px;
+  color: var(--neutral-400, #9b9592);
+  line-height: 1.5;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--neutral-200, #f0edeb);
+}
+
+.omchai-card__users {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.omchai-card__empty {
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--neutral-400, #9b9592);
+  font-style: italic;
+}
+
+.omchai-user-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--neutral-100, #faf8f7);
+  border-radius: 8px;
+  border: 1px solid var(--neutral-200, #f0edeb);
+}
+
+.omchai-user-chip__name {
+  font-family: var(--font-body, 'Open Sans', sans-serif);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--neutral-600, #2d2926);
+}
+
+.omchai-user-chip__title {
+  font-family: var(--font-body, 'Open Sans', sans-serif);
+  font-size: 13px;
+  color: var(--neutral-400, #9b9592);
+}

--- a/apps/frontend/src/containers/projects-publication/omchai-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/omchai-view.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useState } from 'react';
+import apiClient from '../../api/apiClient';
+import { OmchaiEntry, OmchaiRole } from '../../types';
+import './omchai-view.css';
+
+interface Props {
+  anthologyId: number;
+}
+
+const ROLE_META: Record<OmchaiRole, { label: string; description: string }> = {
+  [OmchaiRole.OWNER]: {
+    label: 'Owner',
+    description:
+      'Has overall responsibility for the success or failure of the project. Ensures that all the work gets done and that others are involved appropriately.',
+  },
+  [OmchaiRole.MANAGER]: {
+    label: 'Manager',
+    description:
+      'Assigns responsibility and holds the owner accountable. Makes suggestions, asks hard questions, reviews progress, and intervenes if the work is off-track.',
+  },
+  [OmchaiRole.CONSULTED]: {
+    label: 'Consulted',
+    description:
+      'Should be asked for input or needs to be bought in to the project.',
+  },
+  [OmchaiRole.HELPER]: {
+    label: 'Helper',
+    description: 'Assists with or does some of the work.',
+  },
+  [OmchaiRole.APPROVER]: {
+    label: 'Approver',
+    description:
+      "Signs off on decisions before they're final. May be the manager, executive director, students, or an external partner.",
+  },
+  [OmchaiRole.INFORMED]: {
+    label: 'Informed',
+    description:
+      'Is kept updated about progress in the project at designated points.',
+  },
+};
+
+const ROLE_ORDER: OmchaiRole[] = [
+  OmchaiRole.OWNER,
+  OmchaiRole.MANAGER,
+  OmchaiRole.CONSULTED,
+  OmchaiRole.HELPER,
+  OmchaiRole.APPROVER,
+  OmchaiRole.INFORMED,
+];
+
+const OmchaiView: React.FC<Props> = ({ anthologyId }) => {
+  const [entries, setEntries] = useState<OmchaiEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedRoles, setExpandedRoles] = useState<Set<OmchaiRole>>(
+    new Set(),
+  );
+
+  const toggleDescription = (role: OmchaiRole) => {
+    setExpandedRoles((prev) => {
+      const next = new Set(prev);
+      if (next.has(role)) {
+        next.delete(role);
+      } else {
+        next.add(role);
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    apiClient
+      .getOmchaiByAnthology(anthologyId)
+      .then((data) => {
+        setEntries(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [anthologyId]);
+
+  if (loading) return <div className="omchai-loading">Loading OMCHAI...</div>;
+
+  const byRole = new Map<OmchaiRole, OmchaiEntry[]>();
+  for (const entry of entries) {
+    const list = byRole.get(entry.role) ?? [];
+    list.push(entry);
+    byRole.set(entry.role, list);
+  }
+
+  return (
+    <div className="omchai-grid">
+      {ROLE_ORDER.map((role) => {
+        const meta = ROLE_META[role];
+        const assigned = byRole.get(role) ?? [];
+        const isExpanded = expandedRoles.has(role);
+
+        return (
+          <div key={role} className="omchai-card">
+            <div className="omchai-card__header">
+              <h3 className="omchai-card__title">{meta.label}</h3>
+              <button
+                type="button"
+                className="omchai-card__toggle"
+                onClick={() => toggleDescription(role)}
+                aria-label={
+                  isExpanded ? 'Hide description' : 'Show description'
+                }
+              >
+                {isExpanded ? '−' : '?'}
+              </button>
+            </div>
+            {isExpanded && (
+              <p className="omchai-card__desc">{meta.description}</p>
+            )}
+            <div className="omchai-card__users">
+              {assigned.length === 0 ? (
+                <span className="omchai-card__empty">No one assigned</span>
+              ) : (
+                assigned
+                  .filter((entry) => entry.user)
+                  .map((entry) => (
+                    <div key={entry.id} className="omchai-user-chip">
+                      <span className="omchai-user-chip__name">
+                        {entry.user.firstName} {entry.user.lastName}
+                      </span>
+                      {entry.user.title && (
+                        <span className="omchai-user-chip__title">
+                          {entry.user.title}
+                        </span>
+                      )}
+                    </div>
+                  ))
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default OmchaiView;

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.css
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.css
@@ -41,6 +41,14 @@
   margin: 0;
 }
 
+.publication-tabs button.publication-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
 .ppv-tab-content {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
+++ b/apps/frontend/src/containers/projects-publication/project-publication-view.tsx
@@ -3,7 +3,10 @@ import { useParams } from 'react-router-dom';
 import apiClient from '../../api/apiClient';
 import { Anthology, Author } from '../../types';
 import NewStoryDraftModal from './new-story-draft-modal';
+import OmchaiView from './omchai-view';
 import './project-publication-view.css';
+
+type Tab = 'omchai' | 'document-tracker';
 
 interface StoryDraftRow {
   firstName: string;
@@ -17,6 +20,7 @@ const ProjectPublicationView: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [anthology, setAnthology] = useState<Anthology | null>(null);
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<Tab>('omchai');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [storyDrafts, setStoryDrafts] = useState<StoryDraftRow[]>([]);
 
@@ -49,7 +53,7 @@ const ProjectPublicationView: React.FC = () => {
     } catch {
       // Story drafts will remain as-is on fetch failure
     }
-  }, []);
+  }, [id]);
 
   useEffect(() => {
     if (id) {
@@ -64,8 +68,10 @@ const ProjectPublicationView: React.FC = () => {
   }, [id]);
 
   useEffect(() => {
-    loadStoryDrafts();
-  }, [loadStoryDrafts]);
+    if (activeTab === 'document-tracker') {
+      loadStoryDrafts();
+    }
+  }, [activeTab, loadStoryDrafts]);
 
   if (loading) return <div className="ppv-wrapper">Loading...</div>;
   if (!anthology)
@@ -85,64 +91,91 @@ const ProjectPublicationView: React.FC = () => {
         <h1 className="ppv-title">{anthology.title}</h1>
 
         <div className="publication-tabs">
-          <span className="publication-tab publication-tab--active">
+          <button
+            type="button"
+            className={`publication-tab${
+              activeTab === 'omchai' ? ' publication-tab--active' : ''
+            }`}
+            onClick={() => setActiveTab('omchai')}
+          >
+            OMCHAI
+          </button>
+          <button
+            type="button"
+            className={`publication-tab${
+              activeTab === 'document-tracker' ? ' publication-tab--active' : ''
+            }`}
+            onClick={() => setActiveTab('document-tracker')}
+          >
             Document Tracker
-          </span>
+          </button>
         </div>
 
-        <div className="ppv-tab-content">
-          <div className="document-tracker-header">
-            <button
-              type="button"
-              className="publication-create-btn"
-              onClick={() => setIsModalOpen(true)}
-            >
-              New Story Draft
-            </button>
+        {activeTab === 'omchai' && (
+          <div className="ppv-tab-content">
+            <OmchaiView anthologyId={anthology.id} />
           </div>
+        )}
 
-          <table className="document-tracker-table">
-            <thead>
-              <tr>
-                <th>First Name</th>
-                <th>Last Name</th>
-                <th>Name in Book</th>
-                <th>Class Period</th>
-                <th>Document Link</th>
-              </tr>
-            </thead>
-            <tbody>
-              {storyDrafts.length === 0 ? (
+        {activeTab === 'document-tracker' && (
+          <div className="ppv-tab-content">
+            <div className="document-tracker-header">
+              <button
+                type="button"
+                className="publication-create-btn"
+                onClick={() => setIsModalOpen(true)}
+              >
+                New Story Draft
+              </button>
+            </div>
+
+            <table className="document-tracker-table">
+              <thead>
                 <tr>
-                  <td
-                    colSpan={5}
-                    style={{
-                      textAlign: 'center',
-                      color: 'var(--neutral-400)',
-                      padding: '24px',
-                    }}
-                  >
-                    No story drafts yet.
-                  </td>
+                  <th>First Name</th>
+                  <th>Last Name</th>
+                  <th>Name in Book</th>
+                  <th>Class Period</th>
+                  <th>Document Link</th>
                 </tr>
-              ) : (
-                storyDrafts.map((draft, i) => (
-                  <tr key={i}>
-                    <td>{draft.firstName}</td>
-                    <td>{draft.lastName}</td>
-                    <td>{draft.nameInBook}</td>
-                    <td>{draft.classPeriod}</td>
-                    <td>
-                      <a href={draft.docLink} target="_blank" rel="noreferrer">
-                        Open
-                      </a>
+              </thead>
+              <tbody>
+                {storyDrafts.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      style={{
+                        textAlign: 'center',
+                        color: 'var(--neutral-400)',
+                        padding: '24px',
+                      }}
+                    >
+                      No story drafts yet.
                     </td>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                ) : (
+                  storyDrafts.map((draft, i) => (
+                    <tr key={i}>
+                      <td>{draft.firstName}</td>
+                      <td>{draft.lastName}</td>
+                      <td>{draft.nameInBook}</td>
+                      <td>{draft.classPeriod}</td>
+                      <td>
+                        <a
+                          href={draft.docLink}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open
+                        </a>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       {isModalOpen && (

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -88,6 +88,31 @@ export const DEFAULT_FILTER_STATE: FilterState = {
   inventoryMax: '',
 };
 
+export enum OmchaiRole {
+  OWNER = 'OWNER',
+  MANAGER = 'MANAGER',
+  CONSULTED = 'CONSULTED',
+  HELPER = 'HELPER',
+  APPROVER = 'APPROVER',
+  INFORMED = 'INFORMED',
+}
+
+export interface OmchaiUser {
+  id: number;
+  firstName: string;
+  lastName: string;
+  title?: string;
+}
+
+export interface OmchaiEntry {
+  id: number;
+  anthologyId: number;
+  userId: number;
+  role: OmchaiRole;
+  datetimeAssigned: string;
+  user: OmchaiUser;
+}
+
 export interface Anthology {
   id: number;
   title: string;

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -1,10 +1,11 @@
 import { PUB_LEVEL_OPTIONS } from '@containers/archived-publications/filter-modal/constants';
 
 export enum AnthologyStatus {
+  DRAFT = 'Draft',
+  IN_REVISION = 'In Revision',
+  IN_PRODUCTION = 'In Production',
+  PUBLISHED = 'Published',
   ARCHIVED = 'Archived',
-  NOT_STARTED = 'NotStarted',
-  DRAFTING = 'Drafting',
-  CAN_BE_SHARED = 'CanBeShared',
 }
 
 export enum AnthologyPubLevel {


### PR DESCRIPTION
# closes #121 

## Summary
Adds an OMCHAI tab to the individual project page that displays all OMCHAI roles from what i figured out from the spreadsheet (Owner, Manager, Consulted, Helper, Approver, Informed) with their assigned users, fetched live from the backend. 

## testing
- run yarn db:reset (new test migrations)
- projects > click on something (/projects/publication/5 is what i put seed data for)
- omchai tab with roles is default landing tab
- click 'document tracker' to enter the story drafts view

## Changes

Backend
- `OmchaiService.findByAnthologyId()` — added `relations: ['user']` to load user data with each entry
- `omchai.entity.ts` — fixed `@JoinColumn` names to match actual DB column names (`userId`, `anthologyId`) since the `PluralNamingStrategy` ignores explicit column name overrides apparently

Seeds
- `users.seed.ts` — added 2 new users (Program Assistant, Publishing Fellow)
- `omchai.seed.ts` — removed duplicate IDs, removed hardcoded IDs, added full seed data for anthology 5 with all 6 roles and multi-user entries (Manager, Consulted, Helper, Informed each have 2+ users)
- `seed-omchai.ts` — fixed dedup check to include `role` (a user can have multiple roles per anthology)

Frontend
- `types.ts` — added `OmchaiRole` enum, `OmchaiUser` and `OmchaiEntry` interfaces
- `apiClient.ts` — added `getOmchaiByAnthology(anthologyId)` method
- `omchai-view.tsx` (new) — card-based layout for each role with collapsible descriptions (default collapsed) and user chips showing name + title
- `omchai-view.css` (new) — responsive grid, card styles, toggle button, user chip styles
- `project-publication-view.tsx` — added tab switching between OMCHAI (default) and Document Tracker; tabs are now clickable buttons; story drafts only load when Document Tracker tab is active
- `project-publication-view.css` — added button reset styles for tab elements

### screenshots: 

<img width="1238" height="938" alt="image" src="https://github.com/user-attachments/assets/ce41f78e-ca2a-4487-8e59-6e24493ee544" />
