### PR TITLE
fixed bug in apiClient where anthology was assumed to be known

### DIFF
--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -32,7 +32,7 @@ function normalizeAnthology(raw: unknown): Anthology {
   const url =
     (typeof o.photo_url === 'string' ? o.photo_url : undefined) ??
     (typeof o.photoUrl === 'string' ? o.photoUrl : undefined);
-  return { ...(o as Anthology), photo_url: url, photoUrl: url };
+  return { ...(o as unknown as Anthology), photo_url: url, photoUrl: url };
 }
 
 function normalizeAnthologies(raw: unknown): Anthology[] {

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -13,16 +13,27 @@ import PeopleIcon from '../assets/icons/people.svg';
 import ChevronRightIcon from '../assets/icons/chevron-right.svg';
 import CollapseArrowIcon from '../assets/icons/collapse-arrow.svg';
 import LogoutIcon from '../assets/icons/logout.svg';
+import { Amplify } from 'aws-amplify';
+import { signOut } from 'aws-amplify/auth';
+import CognitoAuthConfig from '../../../shared/aws-exports';
+import { useNavigate } from 'react-router-dom';
+
+Amplify.configure(CognitoAuthConfig);
 
 const Sidebar: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
   const location = useLocation();
   const [, , user] = useAuth();
+  const navigate = useNavigate();
 
   const isLibraryActive =
     location.pathname.startsWith('/archive') || location.pathname === '/';
   const isAuthorized =
     user?.role === Role.ADMIN || user?.role === Role.STANDARD;
+
+  async function handleSignOut() {
+    await signOut();
+  }
 
   return (
     <aside className={`root-sidebar ${collapsed ? 'collapsed' : ''}`}>
@@ -112,12 +123,27 @@ const Sidebar: React.FC = () => {
         </nav>
       </div>
 
-      {/* Logout */}
+      {/* Login/Logout */}
       <div className="sidebar-logout-section">
-        <button type="button" className="sidebar-logout">
-          <img src={LogoutIcon} alt="" className="sidebar-logout-icon" />
-          {!collapsed && <span>Log Out</span>}
-        </button>
+        {user ? (
+          <button
+            type="button"
+            className="sidebar-logout"
+            onClick={handleSignOut}
+          >
+            <img src={LogoutIcon} alt="" className="sidebar-logout-icon" />
+            {!collapsed && <span>Log Out</span>}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="sidebar-logout"
+            onClick={() => navigate('/login')}
+          >
+            <img src={LogoutIcon} alt="" className="sidebar-logout-icon" />
+            {!collapsed && <span>Sign In</span>}
+          </button>
+        )}
       </div>
     </aside>
   );


### PR DESCRIPTION
### ℹ️ Issue

Closes #165 

### 📝 Description

1. Log in / log out button in bottom left corner toggles based on user signed in status
2. Pressing log in triggers /login route

### ✔️ Verification

Both log in and log out are successful!
[Screencast from 04-17-2026 04:14:37 PM.webm](https://github.com/user-attachments/assets/8a1a72da-9a9a-455d-9cbc-0a547a74ba63)



### 🏕️ (Optional) Future Work / Notes

Archive still not viewable if not logged in. 
Manual refresh required to see permission changes on route guards
