### PR TITLE
get stories by anthology endpoint and testing

### DIFF
--- a/apps/backend/src/author/author.service.ts
+++ b/apps/backend/src/author/author.service.ts
@@ -44,12 +44,14 @@ export class AuthorService {
     return this.repo.save(author);
   }
 
-  findOne(id: number) {
-    if (!id) {
-      return null;
+  async findOne(id: number): Promise<Author> {
+    const author = await this.repo.findOneBy({ id });
+
+    if (!author) {
+      throw new NotFoundException('Author not found');
     }
 
-    return this.repo.findOneBy({ id });
+    return author;
   }
 
   findAll() {

--- a/apps/backend/src/story/story.controller.spec.ts
+++ b/apps/backend/src/story/story.controller.spec.ts
@@ -1,0 +1,64 @@
+import { AnthologyService } from '../anthology/anthology.service';
+import { StoryController } from './story.controller';
+import { StoryService } from './story.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthorService } from '../author/author.service';
+import { StoriesSeed } from '../seeds/stories.seed';
+
+describe('StoryController', () => {
+  let controller: StoryController;
+
+  const mockService = {
+    findOne: jest.fn(),
+    findAll: jest.fn(),
+    getStoriesByAnthology: jest.fn(),
+    findByTitle: jest.fn(),
+    findByTheme: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    findByAnthologyAndId: jest.fn(),
+    createStory: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StoryController],
+      providers: [
+        { provide: StoryService, useValue: mockService },
+        {
+          provide: AnthologyService,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: AuthorService,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<StoryController>(StoryController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('get stories by anthology', () => {
+    it('get stories given anthology id', () => {
+      mockService.getStoriesByAnthology.mockResolvedValue([StoriesSeed[0]]);
+      const result = controller.getStoriesByAnthology(999);
+      expect(result).resolves.toEqual([StoriesSeed[0]]);
+      expect(mockService.getStoriesByAnthology).toHaveBeenCalledWith(999);
+    });
+  });
+
+  // todo: other tests
+});

--- a/apps/backend/src/story/story.controller.ts
+++ b/apps/backend/src/story/story.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Param,
   ParseIntPipe,
-  UseGuards,
   Post,
   Body,
   HttpCode,
@@ -22,7 +21,6 @@ import {
 import { AnthologyService } from '../anthology/anthology.service';
 import { AuthorService } from '../author/author.service';
 import { CreateStoryDto } from './dtos/create-story.dto';
-import { create } from 'domain';
 import { Public } from 'src/auth/roles.decorator';
 
 @ApiTags('Story')
@@ -34,6 +32,24 @@ export class StoryController {
     private anthologyService: AnthologyService,
     private authorService: AuthorService,
   ) {}
+
+  @Public()
+  @Get('/anthology/:anthologyId')
+  async getStoriesByAnthology(
+    @Param('anthologyId', ParseIntPipe) anthologyId: number,
+  ): Promise<Story[]> {
+    const stories = await this.storyService.getStoriesByAnthology(anthologyId);
+
+    // get authors for each story
+    await Promise.all(
+      stories.map(async (story) => {
+        const authorId = story.authorId;
+        story.author = await this.authorService.findOne(authorId);
+      }),
+    );
+
+    return stories;
+  }
 
   @Public()
   @Get('/library/anthology/:anthologyId/story/:storyId')

--- a/apps/backend/src/story/story.service.spec.ts
+++ b/apps/backend/src/story/story.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Story } from './story.entity';
+import { StoryService } from './story.service';
+import { StoriesSeed } from '../seeds/stories.seed';
+
+describe('StoryService', () => {
+  let service: StoryService;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOneBy: jest.fn(),
+    find: jest.fn(),
+    count: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StoryService,
+        {
+          provide: getRepositoryToken(Story),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<StoryService>(StoryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('get stories by anthology', () => {
+    it('get stories given anthology id', () => {
+      mockRepository.find.mockImplementation((query) => {
+        if (query.where?.anthologyId === 999) {
+          return Promise.resolve([StoriesSeed[0]]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result1 = service.getStoriesByAnthology(999);
+      expect(result1).resolves.toEqual([StoriesSeed[0]]);
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { anthologyId: 999 },
+      });
+
+      const result2 = service.getStoriesByAnthology(1);
+      expect(result2).resolves.toEqual([]);
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { anthologyId: 1 },
+      });
+    });
+  });
+});

--- a/apps/backend/src/story/story.service.ts
+++ b/apps/backend/src/story/story.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { Story } from './story.entity';
+import { Anthology } from 'src/anthology/anthology.entity';
 
 @Injectable()
 export class StoryService {
@@ -18,6 +19,10 @@ export class StoryService {
 
   findAll() {
     return this.repo.find();
+  }
+
+  async getStoriesByAnthology(anthologyId: number) {
+    return this.repo.find({ where: { anthologyId: anthologyId } });
   }
 
   findByTitle(title: string) {

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -74,9 +74,7 @@ export class ApiClient {
   public async getStoriesByAnthology(
     anthologyId: string | number,
   ): Promise<Story[]> {
-    return this.get(`/api/anthologies/${anthologyId}/stories`) as Promise<
-      Story[]
-    >;
+    return this.get(`/api/story/anthology/${anthologyId}`) as Promise<Story[]>;
   }
 
   public async filterSortAnthologies(


### PR DESCRIPTION
### ℹ️ Issue
#161 
bug fix: authors not displaying in individual publication view from library
apiClient was calling endpoint to get all stories in given anthology but this did not exist in backend

### 📝 Description

backend endpoint to get all stories in anthology including author details
controller and service testing


### ✔️ Verification

controller and service testing
individual publication view with author details (previously said No Authors Available)
<img width="1217" height="666" alt="image" src="https://github.com/user-attachments/assets/8900e70d-d53d-49a2-ab02-25d8189dfc50" />

### 🏕️ (Optional) Future Work / Notes
controller and service testing for other story endpoints needs to be implemented